### PR TITLE
Restore all tests by removing harmful unittests/__init__.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.6"
 
 install:
+  - pip install tox-travis
   - pip install -r requirements.txt
   - pip install -r requirements_tests.txt
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 
 install:
   - pip install -r requirements.txt
+  - pip install .
 
 script: 
   - pytest -v --cov-report= --cov=plasTeX 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ python:
 
 install:
   - pip install -r requirements.txt
+  - pip install -r requirements_tests.txt
   - pip install .
 
 script: 
-  - pytest -v --cov-report= --cov=plasTeX 
+  - tox
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.6"
 
 install:
-  - apt-get install -y dvipng
+  - sudo apt-get install -y dvipng
   - pip install -r requirements.txt
   - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 
 python:
+  - "3.3"
+  - "3.4"
+  - "3.5"
   - "3.6"
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
 
 install:
+  - apt-get install -y dvipng
   - pip install -r requirements.txt
   - pip install .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.6"
 
 install:
-  - sudo apt-get install -y dvipng
   - pip install -r requirements.txt
   - pip install .
 

--- a/README.md
+++ b/README.md
@@ -35,16 +35,18 @@ though.  See the documentation at http://tiarno.github.io/plastex/ for a complet
 view of what it is capable of.
 
 ## Testing
-To run the tests locally, make sure you have a [virtual env](https://docs.python.org/3/library/venv.html) enabled, and all the requirements installed, then run pytest:
-```
+To run the tests locally, make sure you have all the requirements installed, then run tox:
+```bash
 # install venv and requirements (optional, recommended)
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+pip install -r requirements_tests.txt
 
 # run the tests
-pytest
+tox
 ```
+This will run tests locally using python 3.3 to 3.6.
 
 ## Status
 [![Build Status](https://travis-ci.org/niklasp/plastex.svg?branch=python3)](https://travis-ci.org/niklasp/plastex)

--- a/plasTeX/Imagers/dvi2bitmap.py
+++ b/plasTeX/Imagers/dvi2bitmap.py
@@ -10,7 +10,7 @@ class DVI2Bitmap(_Imager):
     fileExtension = '.png'
 
     def writePreamble(self, document):
-        plasTeX.Imagers.Imager.writePreamble(self, document)
+        _Imager.writePreamble(self, document)
         self.source.write('\\special{dvi2bitmap default imageformat png}\n')
         self.source.write('\\special{dvi2bitmap default unit pixels}\n')
 

--- a/plasTeX/Imagers/gspdfpng.py
+++ b/plasTeX/Imagers/gspdfpng.py
@@ -2,6 +2,7 @@
 
 from plasTeX.Logging import getLogger
 from plasTeX.Imagers import Imager as _Imager
+import plasTeX
 import glob, sys
 
 status = getLogger('status')

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -1364,7 +1364,7 @@ class TeX(object):
 
         except:
             fullname = ''
-            paths = os.environ["TEXINPUTS"].split(os.path.pathsep)
+            paths = os.environ.get("TEXINPUTS", '').split(os.path.pathsep)
             for path in [x for x in paths if x]:
                 if name in os.listdir(path):
                     fullname = os.path.join(path,name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pytest==3.2.3
 pytest-cov==2.5.1
 requests==2.18.4
 urllib3==1.22
+Unidecode==0.4.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,5 @@
-beautifulsoup4==4.6.0
-bs4==0.0.1
 certifi==2017.7.27.1
 chardet==3.0.4
-coverage==4.4.1
-coveralls==1.2.0
 docopt==0.6.2
-idna==2.6
 Jinja2==2.9.6
-py==1.4.34
-pytest==3.2.3
-pytest-cov==2.5.1
-requests==2.18.4
-urllib3==1.22
 Unidecode==0.4.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ coverage==4.4.1
 coveralls==1.2.0
 docopt==0.6.2
 idna==2.6
+Jinja2==2.9.6
 py==1.4.34
 pytest==3.2.3
 pytest-cov==2.5.1

--- a/requirements_tests.txt
+++ b/requirements_tests.txt
@@ -1,0 +1,9 @@
+py==1.4.34
+pytest==3.2.3
+pytest-cov==2.5.1
+tox==2.9.1
+beautifulsoup4==4.6.0
+bs4==0.0.1
+coverage==4.4.1
+coveralls==1.2.0
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py33, py34, py35, py36
+
+[testenv]
+commands=
+  pip install -r requirements_tests.txt 
+  pytest -v --cov-report= --cov=plasTeX
+deps = -rrequirements.txt

--- a/unittests/FunctionalPackageResource.py
+++ b/unittests/FunctionalPackageResource.py
@@ -1,4 +1,4 @@
-import os, unittest
+import os
 
 from plasTeX.TeX import TeX
 from plasTeX.TeX import TeXDocument
@@ -7,7 +7,6 @@ from plasTeX.Config import config
 from plasTeX.Renderers.HTML5.Config import config as html5_config
 
 
-@unittest.skip("skipping for now")
 def test_package_resource(tmpdir):
 	doc = TeXDocument(config=config+html5_config)
 	tex = TeX(doc)

--- a/unittests/Packages/Alltt.py
+++ b/unittests/Packages/Alltt.py
@@ -61,7 +61,6 @@ class Alltt(TestCase):
 
         return Soup(output).findAll('pre')[-1]
 
-    @unittest.skip("skipping for now")
     def testSimple(self):
         text = '''\\begin{alltt}\n   line 1\n   line 2\n   line 3\n\\end{alltt}'''
         lines = ['', '   line 1', '   line 2', '   line 3', '']
@@ -78,7 +77,6 @@ class Alltt(TestCase):
         plines = out.string.split('\n')
         assert lines == plines, 'Content doesn\'t match - %s - %s' % (lines, plines)
 
-    @unittest.skip("skipping for now")
     def testCommands(self):
         text = '''\\begin{alltt}\n   line 1\n   \\textbf{line} 2\n   \\textit{line 3}\n\\end{alltt}'''
         lines = ['', '   line 1', '   line 2', '   line 3', '']

--- a/unittests/Packages/Alltt.py
+++ b/unittests/Packages/Alltt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import unittest, re, os, tempfile, shutil
+import unittest, re, os 
 from plasTeX.TeX import TeX
 from unittest import TestCase
 
@@ -14,93 +14,82 @@ except ImportError:
     from BeautifulSoup import BeautifulSoup as Soup
 
 
-class Alltt(TestCase):
+def runDocument(content):
+    """
+    Compile a document with the given content
 
-    def runDocument(self, content):
-        """
-        Compile a document with the given content
+    Arguments:
+    content - string containing the content of the document
 
-        Arguments:
-        content - string containing the content of the document
+    Returns: TeX document
 
-        Returns: TeX document
+    """
+    tex = TeX()
+    tex.disableLogging()
+    tex.input(r'''\document{article}\usepackage{alltt}\begin{document}%s\end{document}''' % content)
+    return tex.parse()
 
-        """
-        tex = TeX()
-        tex.disableLogging()
-        tex.input(r'''\document{article}\usepackage{alltt}\begin{document}%s\end{document}''' % content)
-        return tex.parse()
+def runPreformat(content, tmpdir):
+    """
+    This method compiles and renders a document fragment and
+    returns the result
 
-    def runPreformat(self, content):
-        """
-        This method compiles and renders a document fragment and
-        returns the result
+    Arguments:
+    content - string containing the document fragment
 
-        Arguments:
-        content - string containing the document fragment
+    Returns: content of output file
 
-        Returns: content of output file
+    """
+    # Create document file
+    document = r'\documentclass{article}\usepackage{alltt}\begin{document}%s\end{document}' % content
+    srcfile = tmpdir.join('longtable.tex')
+    srcfile.write(document)
 
-        """
-        # Create document file
-        document = r'\documentclass{article}\usepackage{alltt}\begin{document}%s\end{document}' % content
-        tmpdir = tempfile.mkdtemp()
-        filename = os.path.join(tmpdir, 'longtable.tex')
-        open(filename, 'w').write(document)
+    # Run plastex on the document
+    log = os.popen(
+            'plastex -d %s %s 2>&1' % (str(tmpdir), str(srcfile))).read()
+    assert '[ index.html ]' in log, 'No file was generated - %s' % log
 
-        # Run plastex on the document
-        log = os.popen('plastex -d %s %s 2>&1' % (tmpdir, filename)).read()
-        assert '[ index.html ]' in log, 'No file was generated - %s' % log
+    # Get output file
+    output = tmpdir.join('index.html').read()
 
-        # Get output file
-        output = open(os.path.join(tmpdir, 'index.html')).read()
+    return Soup(output).findAll('pre')[-1]
 
-        # Clean up
-        shutil.rmtree(tmpdir)
-        os.remove('longtable.paux')
+def test_simple(tmpdir):
+    text = '''\\begin{alltt}\n   line 1\n   line 2\n   line 3\n\\end{alltt}'''
+    lines = ['', '   line 1', '   line 2', '   line 3', '']
 
-        return Soup(output).findAll('pre')[-1]
+    # Test text content of node
+    out = runDocument(text).getElementsByTagName('alltt')[0]
 
-    def testSimple(self):
-        text = '''\\begin{alltt}\n   line 1\n   line 2\n   line 3\n\\end{alltt}'''
-        lines = ['', '   line 1', '   line 2', '   line 3', '']
+    plines = out.textContent.split('\n')
+    assert lines == plines, 'Content doesn\'t match - %s - %s' % (lines, plines)
 
-        # Test text content of node
-        out = self.runDocument(text).getElementsByTagName('alltt')[0]
+    # Test text content of rendering
+    out = runPreformat(text, tmpdir)
 
-        plines = out.textContent.split('\n')
-        assert lines == plines, 'Content doesn\'t match - %s - %s' % (lines, plines)
+    plines = out.string.split('\n')
+    assert lines == plines, 'Content doesn\'t match - %s - %s' % (lines, plines)
 
-        # Test text content of rendering
-        out = self.runPreformat(text)
+def test_commands(tmpdir):
+    text = '''\\begin{alltt}\n   line 1\n   \\textbf{line} 2\n   \\textit{line 3}\n\\end{alltt}'''
+    lines = ['', '   line 1', '   line 2', '   line 3', '']
 
-        plines = out.string.split('\n')
-        assert lines == plines, 'Content doesn\'t match - %s - %s' % (lines, plines)
+    # Test text content of node
+    out = runDocument(text).getElementsByTagName('alltt')[0]
 
-    def testCommands(self):
-        text = '''\\begin{alltt}\n   line 1\n   \\textbf{line} 2\n   \\textit{line 3}\n\\end{alltt}'''
-        lines = ['', '   line 1', '   line 2', '   line 3', '']
+    plines = out.textContent.split('\n')
+    assert lines == plines, 'Content doesn\'t match - %s - %s' % (lines, plines)
 
-        # Test text content of node
-        out = self.runDocument(text).getElementsByTagName('alltt')[0]
+    bf = out.getElementsByTagName('textbf')[0]
+    assert bf.textContent == 'line', 'Bold text should be "line", but it is "%s"' % bf.textContent
 
-        plines = out.textContent.split('\n')
-        assert lines == plines, 'Content doesn\'t match - %s - %s' % (lines, plines)
+    it = out.getElementsByTagName('textit')[0]
+    assert it.textContent == 'line 3', 'Italic text should be "line 3", but it is "%s"' % it.textContent
 
-        bf = out.getElementsByTagName('textbf')[0]
-        assert bf.textContent == 'line', 'Bold text should be "line", but it is "%s"' % bf.textContent
+    # Test rendering
+    out = runPreformat(text, tmpdir)
 
-        it = out.getElementsByTagName('textit')[0]
-        assert it.textContent == 'line 3', 'Italic text should be "line 3", but it is "%s"' % it.textContent
+    assert out.b.string == 'line', 'Bold text should be "line", but it is "%s"' % out.b.string
 
-        # Test rendering
-        out = self.runPreformat(text)
-
-        assert out.b.string == 'line', 'Bold text should be "line", but it is "%s"' % out.b.string
-
-        assert out.i.string == 'line 3', 'Italic text should be "line 3", but it is "%s"' % out.i.string
-
-
-if __name__ == '__main__':
-    unittest.main()
-
+    assert out.i.string == 'line 3', 'Italic text should be "line 3", but it is "%s"' % out.i.string

--- a/unittests/Packages/Alltt.py
+++ b/unittests/Packages/Alltt.py
@@ -1,87 +1,33 @@
 #!/usr/bin/env python
 
-import os 
-from plasTeX.TeX import TeX, TeXDocument
-from plasTeX.Config import config
-from plasTeX.Renderers.XHTML import Renderer
-
-# Will try to use obsolete, but good enough for us, BeautifulSoup 3 if
-# BeautifulSoup 4 is not available. Need to cope with slight API difference
-try:
-    from bs4  import BeautifulSoup
-    def Soup(source):
-        return BeautifulSoup(source, 'html.parser')
-except ImportError:
-    from BeautifulSoup import BeautifulSoup as Soup
+import os
 
 
-def runDocument(content):
-    """
-    Compile a document with the given content
-
-    Arguments:
-    content - string containing the content of the document
-
-    Returns: TeX document
-
-    """
-    
-    doc = TeXDocument(config=config)
-    tex = TeX(doc)
-    tex.disableLogging()
-    tex.input(r'''\documentclass{article}\usepackage{alltt}\begin{document}%s\end{document}''' % content)
-    doc = tex.parse()
-    doc.userdata['working-dir'] = os.path.dirname(__file__)
-    return doc
-
-
-def runPreformat(doc, tmpdir):
-    """
-    This method renders a document in XHTML into tmpdir and
-    returns the last pre tag
-
-    Arguments:
-    doc - the plasTeX document to render
-    tmpdir - the output directory name
-
-    Returns: last pre tag in output
-
-    """
-    # Create document file
-
-    # Run plastex on the document
-    os.chdir(str(tmpdir))
-    Renderer().render(doc)
-    assert tmpdir.join('index.html').isfile()
-
-    # Get output file
-    output = tmpdir.join('index.html').read()
-
-    return Soup(output).findAll('pre')[-1]
-
-def test_simple(tmpdir):
+def test_simple(tmpdir, renderXHTML, make_document):
     text = '''\\begin{alltt}\n   line 1\n   line 2\n   line 3\n\\end{alltt}'''
     lines = ['', '   line 1', '   line 2', '   line 3', '']
 
     # Test text content of node
-    doc = runDocument(text)
+    doc = make_document(packages='alltt', content=text)
     out = doc.getElementsByTagName('alltt')[0]
 
     plines = out.textContent.split('\n')
     assert lines == plines, 'Content doesn\'t match - %s - %s' % (lines, plines)
 
     # Test text content of rendering
-    out = runPreformat(doc, tmpdir)
+    output = renderXHTML(tmpdir, doc)
+    out = output.findAll('pre')[-1]
 
     plines = out.string.split('\n')
     assert lines == plines, 'Content doesn\'t match - %s - %s' % (lines, plines)
 
-def test_commands(tmpdir):
+
+def test_commands(tmpdir, renderXHTML, make_document):
     text = '''\\begin{alltt}\n   line 1\n   \\textbf{line} 2\n   \\textit{line 3}\n\\end{alltt}'''
     lines = ['', '   line 1', '   line 2', '   line 3', '']
 
     # Test text content of node
-    doc = runDocument(text)
+    doc = make_document(packages='alltt', content=text)
     out = doc.getElementsByTagName('alltt')[0]
 
     plines = out.textContent.split('\n')
@@ -94,7 +40,8 @@ def test_commands(tmpdir):
     assert it.textContent == 'line 3', 'Italic text should be "line 3", but it is "%s"' % it.textContent
 
     # Test rendering
-    out = runPreformat(doc, tmpdir)
+    output = renderXHTML(tmpdir, doc)
+    out = output.findAll('pre')[-1]
 
     assert out.b.string == 'line', 'Bold text should be "line", but it is "%s"' % out.b.string
 

--- a/unittests/Packages/Longtable.py
+++ b/unittests/Packages/Longtable.py
@@ -1,191 +1,148 @@
 #!/usr/bin/env python
 
-import unittest, re, os, tempfile, shutil
-from plasTeX.TeX import TeX
-from unittest import TestCase
+import re
 
-# Will try to use obsolete, but good enough for us, BeautifulSoup 3 if
-# BeautifulSoup 4 is not available. Need to cope with slight API difference
-try:
-    from bs4  import BeautifulSoup
-    def Soup(source):
-        return BeautifulSoup(source, 'html.parser')
-except ImportError:
-    from BeautifulSoup import BeautifulSoup as Soup
-
-@unittest.skip("skip class for now as it uses the binary")
-class Longtables(TestCase):
-
-    def runDocument(self, content):
-        """
-        Compile a document with the given content
-
-        Arguments:
-        content - string containing the content of the document
-
-        Returns: TeX document
-
-        """
-        tex = TeX()
-        tex.disableLogging()
-        tex.input(r'''\documentclass{article}\usepackage{longtable}\begin{document}%s\end{document}''' % content)
-        return tex.parse()
-
-    def runTable(self, content):
-        """
-        This method compiles and renders a document fragment and
-        returns the result
-
-        Arguments:
-        content - string containing the document fragment
-
-        Returns: content of output file
-
-        """
-        # Create document file
-        document = r'\documentclass{article}\usepackage{longtable}\begin{document}%s\end{document}' % content
-        tmpdir = tempfile.mkdtemp()
-        filename = os.path.join(tmpdir, 'longtable.tex')
-        open(filename, 'w').write(document)
-
-        # Run plastex on the document
-        log = os.popen('plastex -d %s %s 2>&1' % (tmpdir, filename)).read()
-        assert '[ index.html ]' in log, 'No file was generated - %s' % log
-
-        # Get output file
-        output = open(os.path.join(tmpdir, 'index.html')).read()
-
-        # Clean up
-        shutil.rmtree(tmpdir)
-        os.remove('longtable.paux')
-
-        return Soup(output).find('table', 'tabular')
-
-    
-    def testSimple(self):
-        # Table with no bells or whistles
-        out = self.runTable(r'''\begin{longtable}{lll} 1 & 2 & 3 \\ a & b & c \\\end{longtable}''')
-
-        numrows = len(out.findAll('tr'))
-        assert numrows == 2, 'Wrong number of rows (expecting 2, but got %s): %s' % (numrows, out)
-
-        numcols = len(out.findAll('tr')[0].findAll('td'))
-        assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s): %s' % (numcols, out)
-
-        numcols = len(out.findAll('tr')[1].findAll('td'))
-        assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s): %s' % (numcols, out)
+from pytest import mark
 
 
-    def testHeaders(self):
-        headers = [
-            r'M & N & O \\\endhead',
-            r'M & N & O \\\endfirsthead',
-            r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead',
-            r'M & N & O \\\endfirsthead\n\\\endhead',
-        ]
+def testSimple(tmpdir, renderXHTML, make_document):
+    # Table with no bells or whistles
 
-        # Each header pattern should return the same result
-        for header in headers:
-            out = self.runTable(r'''\begin{longtable}{lll} %s 1 & 2 & 3 \\ a & b & c \\\end{longtable}''' % header)
+    doc = make_document(
+        packages='longtable',
+        content=r'''\begin{longtable}{lll} 1 & 2 & 3 \\ a & b & c \\\end{longtable}''')
+    out = renderXHTML(tmpdir, doc).find('table', 'tabular')
 
-            numrows = len(out.findAll('tr'))
-            assert numrows == 3, 'Wrong number of rows (expecting 3, but got %s) - %s - %s' % (numrows, header, out)
+    numrows = len(out.findAll('tr'))
+    assert numrows == 2, 'Wrong number of rows (expecting 2, but got %s): %s' % (
+        numrows, out)
 
-            headercells = out.findAll('tr')[0].findAll('th')
-            numcols = len(headercells)
-            assert numcols, 'No header cells found'
-            assert numcols == 3, 'Wrong number of headers (expecting 3, but got %s) - %s - %s' % (numcols, header, out)
-            text = [x.p.string.strip() for x in headercells]
-            assert text[0]=='M','Cell should contain M, but contains %s' % text[0]
-            assert text[1]=='N','Cell should contain N, but contains %s' % text[1]
-            assert text[2]=='O','Cell should contain O, but contains %s' % text[2]
+    numcols = len(out.findAll('tr')[0].findAll('td'))
+    assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s): %s' % (
+        numcols, out)
 
-            numcols = len(out.findAll('tr')[1].findAll('td'))
-            assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s) - %s - %s' % (numcols, header, out)
-
-    def testFooters(self):
-        footers = [
-           # Test \endfoot
-            r'M & N & O \\\endhead F & G & H \\\endfoot',
-            r'M & N & O \\\endfirsthead F & G & H \\\endfoot',
-            r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead F & G & H \\\endfoot',
-            r'M & N & O \\\endfirsthead\n\\\endhead F & G & H \\\endfoot',
-            r'M & N & O \\\endhead F & G & H \\\endfoot',
-            r'M & N & O \\\endfirsthead F & G & H \\\endfoot',
-            r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead F & G & H \\\endfoot',
-            r'M & N & O \\\endfirsthead\n\\\endhead F & G & H \\\endfoot',
-
-            # Test \endlastfoot
-            r'M & N & O \\\endhead F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead\n\\\endhead F & G & H \\\endlastfoot',
-            r'M & N & O \\\endhead F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead\n\\\endhead F & G & H \\\endlastfoot',
-
-            # Test both \endfoot and \endlastfoot
-            r'M & N & O \\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead I & J & K \\\endfoot F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead\n\\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot',
-            r'M & N & O \\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead I & J & K \\\endfoot F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot',
-            r'M & N & O \\\endfirsthead\n\\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot',
-        ]
-
-        # Each footer pattern should return the same result
-        for footer in footers:
-            out = self.runTable(r'''\begin{longtable}{lll} %s 1 & 2 & 3 \\ a & b & c \\\end{longtable}''' % footer)
-
-            numrows = len(out.findAll('tr'))
-            assert numrows == 4, 'Wrong number of rows (expecting 4, but got %s) - %s - %s' % (numrows, header, out)
-
-            headercells = out.findAll('tr')[-1].findAll('th')
-            numcols = len(headercells)
-            assert numcols, 'No header cells found'
-            assert numcols == 3, 'Wrong number of headers (expecting 3, but got %s) - %s - %s' % (numcols, header, out)
-            text = [x.p.string.strip() for x in headercells]
-            assert text[0]=='F','Cell should contain F, but contains %s' % text[0]
-            assert text[1]=='G','Cell should contain G, but contains %s' % text[1]
-            assert text[2]=='H','Cell should contain H, but contains %s' % text[2]
-
-            numcols = len(out.findAll('tr')[1].findAll('td'))
-            assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s) - %s - %s' % (numcols, header, out)
-
-    def testCaptionNodes(self):
-        captions = [
-            r'\caption{Caption Text}\\',
-            r'\caption{Caption Text}\\ A & B & C \\\endfirsthead',
-            r'''\caption{Caption Text}\\ A & B & C \\\endfirsthead
-                \caption{Next Caption Text}\\ X & Y & Z \\\endhead''',
-        ]
-
-        for caption in captions:
-            doc = self.runDocument(r'''\begin{longtable}{lll} %s 1 & 2 & 3 \end{longtable}''' % caption)
-
-            # Make sure the caption has been captured by longtable
-            caption = doc.getElementsByTagName('caption')
-            assert not caption, 'Too many captions'
-
-            # Make sure that the caption node matches the caption on the table
-            table = doc.getElementsByTagName('longtable')[0]
-            caption = table.title
-            assert caption is not None, 'Caption is empty'
-            assert table.title.textContent.strip() == u'Caption Text', 'Caption does not match table caption'
-
-    def testKill(self):
-        doc = self.runDocument(r'''\begin{longtable}{lll} 1 & 2 & 3 \\ longtext & & \kill\end{longtable}''')
-
-        table = doc.getElementsByTagName('longtable')[0]
-        rows = table.getElementsByTagName('ArrayRow')
-        assert len(rows) == 1, 'There should be only 1 row, but found %s' % len(rows)
-        content = re.sub(r'\s+', r' ', rows[0].textContent.strip())
-        assert content == '1 2 3', 'Content should be "1 2 3", but is %s' % content
+    numcols = len(out.findAll('tr')[1].findAll('td'))
+    assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s): %s' % (
+        numcols, out)
 
 
-if __name__ == '__main__':
-    unittest.main()
+@mark.parametrize(
+    'header',
+    [r'M & N & O \\\endhead',
+     r'M & N & O \\\endfirsthead',
+     r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead',
+     r'M & N & O \\\endfirsthead\n\\\endhead'])
+def testHeaders(header, tmpdir, renderXHTML, make_document):
+    # Each header pattern should return the same result
+    doc = make_document(
+        packages='longtable',
+        content=r'''\begin{longtable}{lll} %s 1 & 2 & 3 \\ a & b & c \\\end{longtable}''' % header)
 
+    out = renderXHTML(tmpdir, doc).find('table', 'tabular')
+
+    numrows = len(out.findAll('tr'))
+    assert numrows == 3, 'Wrong number of rows (expecting 3, but got %s) - %s - %s' % (
+        numrows, header, out)
+
+    headercells = out.findAll('tr')[0].findAll('th')
+    numcols = len(headercells)
+    assert numcols, 'No header cells found'
+    assert numcols == 3, 'Wrong number of headers (expecting 3, but got %s) - %s - %s' % (
+        numcols, header, out)
+    text = [x.p.string.strip() for x in headercells]
+    assert text[0] == 'M', 'Cell should contain M, but contains %s' % text[0]
+    assert text[1] == 'N', 'Cell should contain N, but contains %s' % text[1]
+    assert text[2] == 'O', 'Cell should contain O, but contains %s' % text[2]
+
+    numcols = len(out.findAll('tr')[1].findAll('td'))
+    assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s) - %s - %s' % (
+        numcols, header, out)
+
+
+@mark.parametrize(
+    'footer',
+    [r'M & N & O \\\endhead F & G & H \\\endfoot',
+     r'M & N & O \\\endfirsthead F & G & H \\\endfoot',
+     r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead F & G & H \\\endfoot',
+     r'M & N & O \\\endfirsthead\n\\\endhead F & G & H \\\endfoot',
+     r'M & N & O \\\endhead F & G & H \\\endfoot',
+     r'M & N & O \\\endfirsthead F & G & H \\\endfoot',
+     r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead F & G & H \\\endfoot',
+     r'M & N & O \\\endfirsthead\n\\\endhead F & G & H \\\endfoot',
+
+     # Test \endlastfoot
+     r'M & N & O \\\endhead F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead\n\\\endhead F & G & H \\\endlastfoot',
+     r'M & N & O \\\endhead F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead\n\\\endhead F & G & H \\\endlastfoot',
+
+     # Test both \endfoot and \endlastfoot
+     r'M & N & O \\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead I & J & K \\\endfoot F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead\n\\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot',
+     r'M & N & O \\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead I & J & K \\\endfoot F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead\n X & Y & Z \\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot',
+     r'M & N & O \\\endfirsthead\n\\\endhead I & J & K \\\endfoot F & G & H \\\endlastfoot'])
+def testFooters(footer, tmpdir, renderXHTML, make_document):
+    doc = make_document(
+        packages='longtable',
+        content=r'''\begin{longtable}{lll} %s 1 & 2 & 3 \\ a & b & c \\\end{longtable}''' % footer)
+    out = renderXHTML(tmpdir, doc).find('table', 'tabular')
+
+    numrows = len(out.findAll('tr'))
+    assert numrows == 4, 'Wrong number of rows (expecting 4, but got %s) - %s - %s' % (
+        numrows, header, out)
+
+    headercells = out.findAll('tr')[-1].findAll('th')
+    numcols = len(headercells)
+    assert numcols, 'No header cells found'
+    assert numcols == 3, 'Wrong number of headers (expecting 3, but got %s) - %s - %s' % (
+        numcols, header, out)
+    text = [x.p.string.strip() for x in headercells]
+    assert text[0] == 'F', 'Cell should contain F, but contains %s' % text[0]
+    assert text[1] == 'G', 'Cell should contain G, but contains %s' % text[1]
+    assert text[2] == 'H', 'Cell should contain H, but contains %s' % text[2]
+
+    numcols = len(out.findAll('tr')[1].findAll('td'))
+    assert numcols == 3, 'Wrong number of columns (expecting 3, but got %s) - %s - %s' % (
+        numcols, header, out)
+
+
+@mark.parametrize('caption', [
+    r'\caption{Caption Text}\\',
+    r'\caption{Caption Text}\\ A & B & C \\\endfirsthead',
+    r'''\caption{Caption Text}\\ A & B & C \\\endfirsthead
+            \caption{Next Caption Text}\\ X & Y & Z \\\endhead'''])
+def testCaptionNodes(caption, tmpdir, renderXHTML, make_document):
+    doc = make_document(
+        packages='longtable',
+        content=r'''\begin{longtable}{lll} %s 1 & 2 & 3 \end{longtable}''' % caption)
+
+    # Make sure the caption has been captured by longtable
+    caption = doc.getElementsByTagName('caption')
+    assert not caption, 'Too many captions'
+
+    # Make sure that the caption node matches the caption on the table
+    table = doc.getElementsByTagName('longtable')[0]
+    caption = table.title
+    assert caption is not None, 'Caption is empty'
+    assert table.title.textContent.strip(
+    ) == u'Caption Text', 'Caption does not match table caption'
+
+
+def testKill(tmpdir, renderXHTML, make_document):
+    doc = make_document(
+        packages='longtable',
+        content=r'''\begin{longtable}{lll} 1 & 2 & 3 \\ longtext & & \kill\end{longtable}''')
+
+    table = doc.getElementsByTagName('longtable')[0]
+    rows = table.getElementsByTagName('ArrayRow')
+    assert len(rows) == 1, 'There should be only 1 row, but found %s' % len(rows)
+    content = re.sub(r'\s+', r' ', rows[0].textContent.strip())
+    assert content == '1 2 3', 'Content should be "1 2 3", but is %s' % content

--- a/unittests/Packages/conftest.py
+++ b/unittests/Packages/conftest.py
@@ -1,0 +1,59 @@
+import os
+
+# Will try to use obsolete, but good enough for us, BeautifulSoup 3 if
+# BeautifulSoup 4 is not available. Need to cope with slight API difference
+try:
+    from bs4 import BeautifulSoup
+
+    def Soup(source):
+        return BeautifulSoup(source, 'html.parser')
+except ImportError:
+    from BeautifulSoup import BeautifulSoup as Soup
+
+from pytest import fixture
+
+from plasTeX.TeX import TeX, TeXDocument
+from plasTeX.Config import config
+from plasTeX.Renderers.XHTML import Renderer
+
+
+@fixture(scope='session')
+def make_document():
+    def runDocument(packages='', content=''):
+        """
+        Compile a document with the given content
+
+        Arguments:
+        packages - string containing comma separated packages to use
+        content - string containing the content of the document
+
+        Returns: TeX document
+
+        """
+
+        doc = TeXDocument(config=config)
+        tex = TeX(doc)
+        tex.disableLogging()
+        tex.input(r'''
+                \documentclass{article}
+                \usepackage{%s}
+                \begin{document}%s\end{document}''' % (packages, content))
+        doc = tex.parse()
+        doc.userdata['working-dir'] = os.path.dirname(__file__)
+        return doc
+    return runDocument
+
+
+@fixture(scope='session')
+def renderXHTML():
+    def runRenderer(tmpdir, doc):
+        # Create document file
+
+        # Run plastex on the document
+        os.chdir(str(tmpdir))
+        Renderer().render(doc)
+        assert tmpdir.join('index.html').isfile()
+
+        # Get output file
+        return Soup(tmpdir.join('index.html').read())
+    return runRenderer


### PR DESCRIPTION
This reverts 10f51da083851247954aaabc0ad8d540e763c290 from @niklasp which introduced ``unittests/__init__.py``, which messed up imports in tests, which were then marked for skipping.