### PR TITLE
getImage: convert file extensions to lower case

### DIFF
--- a/plasTeX/Imagers/__init__.py
+++ b/plasTeX/Imagers/__init__.py
@@ -828,8 +828,8 @@ class Imager(object):
 
         # Copy or convert the image as needed
         path = self.newFilename()
-        newext = os.path.splitext(path)[-1]
-        oldext = os.path.splitext(name)[-1]
+        newext = os.path.splitext(path)[-1].lower()
+        oldext = os.path.splitext(name)[-1].lower()
         try:
             directory = os.path.dirname(path)
             if directory and not os.path.isdir(directory):


### PR DESCRIPTION
We have a project containing lots of image files with the extensions `.PNG` and `.JPG`. plasTeX was wasting time running these through PIL, because the check on the file's extension is case-sensitive.

This commit converts `newext` and `oldext` to lower-case before comparing.