### PR TITLE
kpsewhich: add the srcDir to relative paths

### DIFF
--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -1352,6 +1352,8 @@ class TeX(object):
 
         try:
             program = self.ownerDocument.config['general']['kpsewhich']
+            if name[0]=='.':
+                name = os.path.join(srcDir, name)
 
             kwargs = {'stdout':subprocess.PIPE}
             if sys.platform.lower().startswith('win'):


### PR DESCRIPTION
kpsewhich doesn't look in any of its path sources for relative filenames, or filenames beginning with a `/`: instead, it just checks the file exists relative to the working directory.

I *think* that kpsewhich should be run with the working directory set to `srcDir` in order to get the same behaviour as TeX, but then you'd have to do some rewriting of the output. A simple-ish workaround is just to prepend the `srcDir` to the name when it's relative, i.e. it starts with a `.`