### PR TITLE
Python 3.7 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 
 python:
   - "3.6"
+  - "3.7"
 
 install:
   - pip install -r requirements.txt

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -17,7 +17,7 @@ Example:
 """
 from io import IOBase
 import string, os, traceback, sys, plasTeX, subprocess, types
-from plasTeX.Tokenizer import Tokenizer, Token, EscapeSequence, Other, EndInput
+from plasTeX.Tokenizer import Tokenizer, Token, EscapeSequence, Other
 from plasTeX import TeXDocument
 from plasTeX.Base.TeX.Primitives import MathShift
 from plasTeX import ParameterCommand, Macro
@@ -270,7 +270,7 @@ class TeX(object):
                     t.parentNode = None
                     yield t
 
-            except (EndInput, StopIteration):
+            except StopIteration:
                 endInput()
 
             # This really shouldn't happen, but just in case...

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -17,7 +17,7 @@ Example:
 """
 from io import IOBase
 import string, os, traceback, sys, plasTeX, subprocess, types
-from plasTeX.Tokenizer import Tokenizer, Token, EscapeSequence, Other
+from plasTeX.Tokenizer import Tokenizer, Token, EscapeSequence, Other, EndInput
 from plasTeX import TeXDocument
 from plasTeX.Base.TeX.Primitives import MathShift
 from plasTeX import ParameterCommand, Macro
@@ -270,7 +270,7 @@ class TeX(object):
                     t.parentNode = None
                     yield t
 
-            except StopIteration:
+            except (EndInput, StopIteration):
                 endInput()
 
             # This really shouldn't happen, but just in case...
@@ -319,7 +319,10 @@ class TeX(object):
 
         while 1:
             # Get the next token
-            token = next()
+            try:
+                token = next()
+            except StopIteration:
+                return
 
             # Token is null, ignore it
             if token is None:

--- a/plasTeX/Tokenizer.py
+++ b/plasTeX/Tokenizer.py
@@ -30,8 +30,6 @@ DEFAULT_CATEGORIES = [
 VERBATIM_CATEGORIES = [''] * 16
 VERBATIM_CATEGORIES[11] = encoding.stringletters()
 
-class EndInput(Exception):
-    pass
 
 class Token(Text):
     """ Base class for all TeX tokens """
@@ -388,7 +386,7 @@ class Tokenizer(object):
             try:
                 token = next(charIter)
             except StopIteration:
-                raise EndInput
+                return
 
             if token.nodeType == ELEMENT_NODE:
                 raise ValueError('Expanded tokens should never make it here')

--- a/plasTeX/Tokenizer.py
+++ b/plasTeX/Tokenizer.py
@@ -30,6 +30,9 @@ DEFAULT_CATEGORIES = [
 VERBATIM_CATEGORIES = [''] * 16
 VERBATIM_CATEGORIES[11] = encoding.stringletters()
 
+class EndInput(Exception):
+    pass
+
 class Token(Text):
     """ Base class for all TeX tokens """
 
@@ -382,7 +385,10 @@ class Tokenizer(object):
                 yield mybuffer.pop(0)
 
             # Get the next character
-            token = next(charIter)
+            try:
+                token = next(charIter)
+            except StopIteration:
+                raise EndInput
 
             if token.nodeType == ELEMENT_NODE:
                 raise ValueError('Expanded tokens should never make it here')


### PR DESCRIPTION
In #109, there is a discussion about `endInput()` being called when there is no more data to be consumed. That can be done while handling `StopIteration` and doesn't need additional exceptions being raised.

This is a simple patch on top of the existing `fix/generator` branch by Kevin D Smith that handles the StopIteration correctly and allows the test suite to pass with Python 3.6 and 3.7.

(I'm looking to land a version of plastex in Debian that is compatible with Python 3.8 as part of the work to move away from Python 2 dependencies.)