### PR TITLE
Sort index so that output is reproducible

### DIFF
--- a/plasTeX/Renderers/XHTML/CHM.zpts
+++ b/plasTeX/Renderers/XHTML/CHM.zpts
@@ -101,7 +101,7 @@ Title=<span tal:replace='self/title/textContent'>My Title</span>
 Help="<span tal:replace='self/title/textContent'>My Title</span>","chm.hhc","chm.hhk","index.html","index.html",,,,,0x73520,,0x383e,[200,200,1000,800],,,,,,,0
 
 [FILES]
-<metal:block tal:repeat="file templates/files/values"><span tal:replace="file">myhtml.htm</span>
+<metal:block tal:define="files templates/files/values; sorted_files python:sequence.sort(files)" tal:repeat="file sorted_files"><span tal:replace="file">myhtml.htm</span>
 </metal:block>
 
 [MERGE FILES]


### PR DESCRIPTION
The reproducible builds project is working to make compilation output bit-for-bit reproducible across builds. This makes software independently verifiable and also helps spot accidental changes to code or package contents. 

This patch from Chris Lamb sorts output from the XHTML template and thereby makes the build of the plastex Debian package reproducible.

From https://bugs.debian.org/779595