### PR TITLE
Use context manage for chdir in tests

### DIFF
--- a/unittests/FunctionalPackageResource.py
+++ b/unittests/FunctionalPackageResource.py
@@ -19,8 +19,10 @@ def test_package_resource(tmpdir):
 	
 	doc = tex.parse()
 	doc.userdata['working-dir'] = os.path.dirname(__file__)
-	os.chdir(str(tmpdir))
-	Renderer().render(doc)
+
+	with tmpdir.as_cwd():
+		Renderer().render(doc)
+
 	assert tmpdir.join('styles', 'test.css').isfile()
 	assert tmpdir.join('js', 'test.js').isfile()
 	assert 'class="em"' in tmpdir.join('index.html').read()

--- a/unittests/Packages/conftest.py
+++ b/unittests/Packages/conftest.py
@@ -50,8 +50,9 @@ def renderXHTML():
         # Create document file
 
         # Run plastex on the document
-        os.chdir(str(tmpdir))
-        Renderer().render(doc)
+        with tmpdir.as_cwd():
+            Renderer().render(doc)
+
         assert tmpdir.join('index.html').isfile()
 
         # Get output file

--- a/unittests/tikzpicture.py
+++ b/unittests/tikzpicture.py
@@ -6,6 +6,7 @@ try:
 except ImportError:
     from mock import Mock
 
+import py.path
 from pytest import mark, fixture
 
 from plasTeX.TeX import TeX, TeXDocument
@@ -63,8 +64,6 @@ def document_cd():
 
 
 def test_tikz_basic_setup(monkeypatch, tmpdir, document):
-    cur_dir = os.getcwd()
-    os.chdir(os.path.dirname(__file__))
     mock_call = Mock()
     mock_move = Mock()
     monkeypatch.setattr('subprocess.call', mock_call)
@@ -73,9 +72,10 @@ def test_tikz_basic_setup(monkeypatch, tmpdir, document):
 
     doc = document()
     tikz_tmpdir = doc.userdata['tikzpicture']['tmp_dir']
-    os.chdir(str(tmpdir))
-    renderer = Renderer()
-    renderer.render(doc)
+
+    with tmpdir.as_cwd():
+        renderer = Renderer()
+        renderer.render(doc)
 
     pics = doc.getElementsByTagName('tikzpicture')
     assert pics
@@ -89,23 +89,23 @@ def test_tikz_basic_setup(monkeypatch, tmpdir, document):
     assert mock_move.called
 
     assert 'TikZ picture' in tmpdir.join('index.html').read()
-    os.chdir(cur_dir)
 
 
 def test_tikz_config_options(monkeypatch, tmpdir, document):
-    cur_dir = os.getcwd()
-    os.chdir(os.path.dirname(__file__))
     mock_call = Mock()
     mock_move = Mock()
     monkeypatch.setattr('subprocess.call', mock_call)
     monkeypatch.setattr('os.remove', Mock)
     monkeypatch.setattr('shutil.move', mock_move)
 
-    doc = document(compiler='xelatex', converter='mockconv', template='tikztemplate')
+    with py.path.local(os.path.dirname(__file__)).as_cwd():
+        doc = document(compiler='xelatex', converter='mockconv', template='tikztemplate')
     tikz_tmpdir = doc.userdata['tikzpicture']['tmp_dir']
-    os.chdir(str(tmpdir))
-    renderer = Renderer()
-    renderer.render(doc)
+
+    with tmpdir.as_cwd():
+        renderer = Renderer()
+        renderer.render(doc)
+
     pics = doc.getElementsByTagName('tikzpicture')
     assert pics
     tex_path = os.path.join(tikz_tmpdir, pics[0].id + '.tex')
@@ -115,11 +115,8 @@ def test_tikz_config_options(monkeypatch, tmpdir, document):
 
     assert 'xelatex' in mock_call.call_args_list[0][0][0]
     assert 'mockconv' in mock_call.call_args_list[1][0][0]
-    os.chdir(cur_dir)
 
 def test_tikzcd_basic_setup(monkeypatch, tmpdir, document_cd):
-    cur_dir = os.getcwd()
-    os.chdir(os.path.dirname(__file__))
     mock_call = Mock()
     mock_move = Mock()
     monkeypatch.setattr('subprocess.call', mock_call)
@@ -128,9 +125,10 @@ def test_tikzcd_basic_setup(monkeypatch, tmpdir, document_cd):
 
     doc = document_cd()
     tikz_tmpdir = doc.userdata['tikzcd']['tmp_dir']
-    os.chdir(str(tmpdir))
-    renderer = Renderer()
-    renderer.render(doc)
+
+    with tmpdir.as_cwd():
+        renderer = Renderer()
+        renderer.render(doc)
 
     pics = doc.getElementsByTagName('tikzcd')
     assert pics
@@ -144,22 +142,22 @@ def test_tikzcd_basic_setup(monkeypatch, tmpdir, document_cd):
     assert mock_move.called
 
     assert 'Commutative diagram' in tmpdir.join('index.html').read()
-    os.chdir(cur_dir)
 
 def test_tikzcd_config_options(monkeypatch, tmpdir, document_cd):
-    cur_dir = os.getcwd()
-    os.chdir(os.path.dirname(__file__))
     mock_call = Mock()
     mock_move = Mock()
     monkeypatch.setattr('subprocess.call', mock_call)
     monkeypatch.setattr('os.remove', Mock)
     monkeypatch.setattr('shutil.move', mock_move)
 
-    doc = document_cd(compiler='xelatex', converter='mockconv', template='tikzcdtemplate')
+    with py.path.local(os.path.dirname(__file__)).as_cwd():
+        doc = document_cd(compiler='xelatex', converter='mockconv', template='tikzcdtemplate')
     tikz_tmpdir = doc.userdata['tikzcd']['tmp_dir']
-    os.chdir(str(tmpdir))
-    renderer = Renderer()
-    renderer.render(doc)
+
+    with tmpdir.as_cwd():
+        renderer = Renderer()
+        renderer.render(doc)
+
     pics = doc.getElementsByTagName('tikzcd')
     assert pics
     tex_path = os.path.join(tikz_tmpdir, pics[0].id + '.tex')
@@ -169,10 +167,8 @@ def test_tikzcd_config_options(monkeypatch, tmpdir, document_cd):
 
     assert 'xelatex' in mock_call.call_args_list[0][0][0]
     assert 'mockconv' in mock_call.call_args_list[1][0][0]
-    os.chdir(cur_dir)
 
 def test_functional(tmpdir):
-    cur_dir = os.getcwd()
     tmpdir.join('test.tex').write(r"""
     \documentclass{article} 
     \usepackage{tikz, tikz-cd}
@@ -186,8 +182,8 @@ def test_functional(tmpdir):
             A \\rar & B
     \end{tikzcd}
     \end{document}""")
-    os.chdir(str(tmpdir))
-    subprocess.call(
+    with tmpdir.as_cwd():
+        subprocess.call(
             ['plastex', '--renderer', 'HTML5', 'test.tex'])
     assert os.path.isdir(str(tmpdir.join('test')))
     assert os.path.isfile(str(tmpdir.join('test', 'index.html')))
@@ -195,5 +191,3 @@ def test_functional(tmpdir):
     svgs = soup.findAll('object')
     for svg in svgs:
             assert os.path.isfile(str(tmpdir.join('test', svg.attrs['data'])))
-
-    os.chdir(cur_dir)


### PR DESCRIPTION
Moving the state around for the tests is error prone. The pytest tmpdir fixture provides a context manager which simplifies these operations greatly.