### PR TITLE
Fix tikz functional test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,16 @@ python:
   - "3.7"
   - "3.8"
 
+addons:
+  apt:
+    packages:
+    - dvipng
+    - pdf2svg
+    - texlive-binaries
+    - texlive-latex-base
+    - texlive-latex-extra
+
+
 install:
   - pip install tox-travis
   - pip install -r requirements.txt

--- a/unittests/tikzpicture.py
+++ b/unittests/tikzpicture.py
@@ -186,7 +186,7 @@ def test_functional(tmpdir):
     commandline = os.environ.get('PLASTEX_COMMANDLINE', 'plastex')
     commandline = shlex.split(commandline)
     with tmpdir.as_cwd():
-        subprocess.call(commandline + [
+        subprocess.check_call(commandline + [
             '--renderer', 'HTML5',
             'test.tex'
         ])

--- a/unittests/tikzpicture.py
+++ b/unittests/tikzpicture.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import subprocess
 from bs4 import BeautifulSoup 
 try:
@@ -182,9 +183,13 @@ def test_functional(tmpdir):
             A \\rar & B
     \end{tikzcd}
     \end{document}""")
+    commandline = os.environ.get('PLASTEX_COMMANDLINE', 'plastex')
+    commandline = shlex.split(commandline)
     with tmpdir.as_cwd():
-        subprocess.call(
-            ['plastex', '--renderer', 'HTML5', 'test.tex'])
+        subprocess.call(commandline + [
+            '--renderer', 'HTML5',
+            'test.tex'
+        ])
     assert os.path.isdir(str(tmpdir.join('test')))
     assert os.path.isfile(str(tmpdir.join('test', 'index.html')))
     soup = BeautifulSoup(tmpdir.join('test', 'index.html').read(), "html.parser")


### PR DESCRIPTION
The current functional test of the tikz handler needs a few fixups:

* it does not check that `plastex` ran correctly
* it requires additional tools to be installed
* it cannot be run in place (only after installation)
