### PR TITLE
Ensure filehandles are closed, processes are finished

### DIFF
--- a/plasTeX/Base/LaTeX/pyuca.py
+++ b/plasTeX/Base/LaTeX/pyuca.py
@@ -78,36 +78,37 @@ class Collator:
         self.load(filename)
 
     def load(self, filename):
-        for line in open(filename):
-            if line.startswith("#") or line.startswith("%"):
-                continue
-            if line.strip() == "":
-                continue
-            line = line[:line.find("#")] + "\n"
-            line = line[:line.find("%")] + "\n"
-            line = line.strip()
-        
-            if line.startswith("@"):
-                pass
-            else:
-                semicolon = line.find(";")
-                charList = line[:semicolon].strip().split()
-                x = line[semicolon:]
-                collElements = []
-                while True:
-                    begin = x.find("[")
-                    if begin == -1:
-                        break                
-                    end = x[begin:].find("]")
-                    collElement = x[begin:begin+end+1]
-                    x = x[begin + 1:]
-    
-                    alt = collElement[1]
-                    chars = collElement[2:-1].split(".")
-                    
-                    collElements.append((alt, chars))
-                integer_points = [int(ch, 16) for ch in charList]
-                self.table.add(integer_points, collElements)
+        with open(filename) as fh:
+            for line in fh:
+                if line.startswith("#") or line.startswith("%"):
+                    continue
+                if line.strip() == "":
+                    continue
+                line = line[:line.find("#")] + "\n"
+                line = line[:line.find("%")] + "\n"
+                line = line.strip()
+
+                if line.startswith("@"):
+                    pass
+                else:
+                    semicolon = line.find(";")
+                    charList = line[:semicolon].strip().split()
+                    x = line[semicolon:]
+                    collElements = []
+                    while True:
+                        begin = x.find("[")
+                        if begin == -1:
+                            break
+                        end = x[begin:].find("]")
+                        collElement = x[begin:begin+end+1]
+                        x = x[begin + 1:]
+
+                        alt = collElement[1]
+                        chars = collElement[2:-1].split(".")
+
+                        collElements.append((alt, chars))
+                    integer_points = [int(ch, 16) for ch in charList]
+                    self.table.add(integer_points, collElements)
 
     def sort_key(self, string):
         

--- a/plasTeX/Context.py
+++ b/plasTeX/Context.py
@@ -234,9 +234,10 @@ class Context(object):
         import pickle
         if os.path.exists(filename):
             try:
-                d = pickle.load(open(filename, 'rb'))
-                if rtype not in list(d.keys()):
-                    d[rtype] = {}
+                with open(filename, 'rb') as fh:
+                    d = pickle.load(fh)
+                    if rtype not in list(d.keys()):
+                        d[rtype] = {}
             except:
                 os.remove(filename)
                 d = {rtype:{}}
@@ -246,7 +247,8 @@ class Context(object):
         for key, value in list(self.persistentLabels.items()):
             data[key] = value.persist()
         try:
-            pickle.dump(d, open(filename, 'wb'))
+            with open(filename, 'wb') as fh:
+                pickle.dump(d, fh)
         except Exception as msg:
             log.warning('Could not save auxiliary information. (%s)' % msg)
 

--- a/plasTeX/Renderers/PageTemplate/__init__.py
+++ b/plasTeX/Renderers/PageTemplate/__init__.py
@@ -524,45 +524,45 @@ class PageTemplate(BaseRenderer):
         defaults = options.copy()
         name = None
         if not options or 'name' not in options:
-            f = open(filename, 'r')
-            for i, line in enumerate(f):
-                # Found a meta-data command
-                if re.match(r'(default-)?\w+:', line):
+            with open(filename, 'r') as f:
+                for i, line in enumerate(f):
+                    # Found a meta-data command
+                    if re.match(r'(default-)?\w+:', line):
 
-                    # Purge any awaiting templates
-                    if template:
-                        try:
-                            num_templates += 1
-                            self.setTemplate(''.join(template), options)
-                        except ValueError as msg:
-                            print('ERROR: %s at line %s in file %s' % (msg, i, filename))
-                        options = defaults.copy()
-                        template = []
+                        # Purge any awaiting templates
+                        if template:
+                            try:
+                                num_templates += 1
+                                self.setTemplate(''.join(template), options)
+                            except ValueError as msg:
+                                print('ERROR: %s at line %s in file %s' % (msg, i, filename))
+                            options = defaults.copy()
+                            template = []
 
-                    # Done purging previous template, start a new one
-                    name, value = line.split(':', 1)
-                    name = name.strip()
-                    value = value.rstrip()
-                    while value.endswith('\\'):
-                        value = value[:-1] + ' '
-                        for line in f:
-                            value += line.rstrip()
-                            break
+                        # Done purging previous template, start a new one
+                        name, value = line.split(':', 1)
+                        name = name.strip()
+                        value = value.rstrip()
+                        while value.endswith('\\'):
+                            value = value[:-1] + ' '
+                            for line in f:
+                                value += line.rstrip()
+                                break
 
-                    value = re.sub(r'\s+', r' ', value.strip())
-                    if name.startswith('default-'):
-                        name = name.split('-')[-1]
-                        defaults[name] = value
-                        if name not in options or num_templates == 0:
+                        value = re.sub(r'\s+', r' ', value.strip())
+                        if name.startswith('default-'):
+                            name = name.split('-')[-1]
+                            defaults[name] = value
+                            if name not in options or num_templates == 0:
+                                options[name] = value
+                        else:
                             options[name] = value
-                    else:
-                        options[name] = value
-                    continue
+                        continue
 
-                if template or (not(template) and line.strip()):
-                    template.append(line)
-                elif not(template) and 'name' in options:
-                    template.append('')
+                    if template or (not(template) and line.strip()):
+                        template.append(line)
+                    elif not(template) and 'name' in options:
+                        template.append('')
 
         else:
             with open(filename, encoding='utf-8') as f:

--- a/unittests/FunctionalTests.py
+++ b/unittests/FunctionalTests.py
@@ -34,6 +34,7 @@ class Process(object):
             kwargs['stderr'] = subprocess.STDOUT
         self.process = subprocess.Popen(args, **kwargs)
         self.log = self.process.stdout.read().decode('utf8')
+        self.process.wait()
         self.returncode = self.process.returncode
         self.process.stdout.close()
         self.process.stdin.close()


### PR DESCRIPTION
The test suite generates a lot of ResourceWarning errors from filehandles that are not closed or subprocess.Popen calls that are not correctly finalised. 

Example:
```
unittests/FunctionalTests.py::test
  /tmp/autopkgtest.AfpzrA/autopkgtest_tmp/unittests/FunctionalTests.py:96: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/autopkgtest.AfpzrA/autopkgtest_tmp/unittests/Packages/benchmarks/babel.html' mode='r' encoding='ANSI_X3.4-1968'>
    bench = open(benchfile).readlines()

unittests/FunctionalTests.py::test
  /usr/lib/python3.7/subprocess.py:883: ResourceWarning: subprocess 392 is still running
    ResourceWarning, source=self)
```

This PR uses context managers for the file handles and calls `wait()` to reap the subprocess correctly.