### PR TITLE
Add pdf2svg imager

### DIFF
--- a/Doc/command.tex
+++ b/Doc/command.tex
@@ -526,6 +526,22 @@ depth information about the vector image and can also be used as
 a backup if the vector image is not supported by the viewer.}
 \end{configuration}
 
+\begin{configuration}{Save temporary files for debugging}
+\options{\longprogramopt{save-image-file} or \longprogramopt{delete-image-file}}
+\config{images}{save-file}
+\default{no}
+specifies whether the temporary images.tex file should be retained after
+compilation. It can be useful to retain the images for debugging purposes.
+\end{configuration}
+
+\begin{configuration}{Scale factor of image}
+\options{\longprogramopt{image-scale-factor}}
+\config{images}{scale-factor}
+\default{1.0}
+the scale factor to apply to images after compilation. Not all imagers respect
+this option.
+\end{configuration}
+
 \subsection{HTML5 Renderer Options\label{sec:config-html5}}
 
 Each renderer can define its own configuration options. This section

--- a/Doc/imager-api.tex
+++ b/Doc/imager-api.tex
@@ -152,7 +152,7 @@ their final location specified in the configuration.
 executes the command that converts the output from the \LaTeX\ compiler
 into image files.
 
-\var{output} is a file object containing the compiled output of the 
+\var{output} is a bytes object containing the compiled output of the
 \LaTeX\ document.
 \end{methoddesc}
 

--- a/plasTeX/Imagers/__init__.py
+++ b/plasTeX/Imagers/__init__.py
@@ -425,6 +425,7 @@ class Imager(object):
 
     # Verification command to determine if the imager is available
     verification = ''
+    verifications = []
 
     fileExtension = '.png'
 
@@ -521,9 +522,16 @@ class Imager(object):
         if self.verification:
             proc = os.popen(self.verification)
             proc.read()
-            if not proc.close():
-                return True
-            return False
+            return not proc.close()
+
+        if self.verifications:
+            for command in self.verifications:
+                proc = os.popen(command)
+                proc.read()
+                if proc.close():
+                    return False
+
+            return True
 
         if not self.command.strip():
             return False

--- a/plasTeX/Imagers/__init__.py
+++ b/plasTeX/Imagers/__init__.py
@@ -9,6 +9,7 @@ from plasTeX.Filenames import Filenames
 from collections import OrderedDict
 import subprocess
 import shlex
+from typing import List, Tuple, Optional
 
 log = getLogger()
 depthlog = getLogger('render.images.depth')
@@ -653,7 +654,7 @@ class Imager(object):
 
         return output
 
-    def executeConverter(self, output):
+    def executeConverter(self, output: bytes) -> Tuple[int, Optional[List[str]]]:
         """
         Execute the actual image converter
 

--- a/plasTeX/Imagers/__init__.py
+++ b/plasTeX/Imagers/__init__.py
@@ -424,7 +424,6 @@ class Imager(object):
     compiler = 'latex'
 
     # Verification command to determine if the imager is available
-    verification = ''
     verifications = []
 
     fileExtension = '.png'
@@ -519,11 +518,6 @@ class Imager(object):
 
     def verify(self):
         """ Verify that this commmand works on this machine """
-        if self.verification:
-            proc = os.popen(self.verification)
-            proc.read()
-            return not proc.close()
-
         if self.verifications:
             for command in self.verifications:
                 proc = os.popen(command)

--- a/plasTeX/Imagers/__init__.py
+++ b/plasTeX/Imagers/__init__.py
@@ -638,12 +638,18 @@ class Imager(object):
                         cmd_line))
         output = None
         for ext in ['.dvi','.pdf','.ps']:
-            if os.path.isfile('images'+ext):
-                output = open('images'+ext, 'rb')
+            try:
+                with open('images'+ext, 'rb') as f:
+                    output = open('images'+ext, 'rb').read()
                 break
+            except OSError:
+                # Ignore if file not found
+                pass
 
         # Change back to original working directory
         os.chdir(cwd)
+        if not self.config["images"]["save-file"]:
+            shutil.rmtree(tempdir, True)
 
         return output
 
@@ -652,7 +658,8 @@ class Imager(object):
         Execute the actual image converter
 
         Arguments:
-        output -- file object pointing to the rendered LaTeX output
+        output -- the content of the rendered LaTeX output, obtained by
+        open(...).read()
 
         Returns:
         two-element tuple.  The first element is the return code of the
@@ -661,7 +668,7 @@ class Imager(object):
         used, you can simply return None.
 
         """
-        open('images.out', 'wb').write(output.read())
+        open('images.out', 'wb').write(output)
         options = ''
         if self._configOptions:
             for opt, value in self._configOptions:

--- a/plasTeX/Imagers/dvisvgm.py
+++ b/plasTeX/Imagers/dvisvgm.py
@@ -6,7 +6,7 @@ from plasTeX.Imagers import VectorImager as _Imager
 class DVISVGM(_Imager):
     """ Imager that uses dvisvgm """
     fileExtension = '.svg'
-    verification = 'dvisvgm --help'
+    verifications = ['dvisvgm --help', 'latex --help']
     compiler = 'latex'
 
     def executeConverter(self, output):

--- a/plasTeX/Imagers/dvisvgm.py
+++ b/plasTeX/Imagers/dvisvgm.py
@@ -11,7 +11,7 @@ class DVISVGM(_Imager):
 
     def executeConverter(self, output):
         rc = 0
-        open('images.dvi', 'wb').write(output.read())
+        open('images.dvi', 'wb').write(output)
         page = 1
         while 1:
             filename = 'img%d.svg' % page

--- a/plasTeX/Imagers/gsdvipng.py
+++ b/plasTeX/Imagers/gsdvipng.py
@@ -13,7 +13,7 @@ class GSDVIPNG(gspdfpng.GSPDFPNG):
     verifications = ['%s --help' % gs, 'dvips --help', 'latex --help']
 
     def executeConverter(self, output):
-        open('images.dvi', 'w').write(output.read())
+        open('images.dvi', 'w').write(output)
         rc = os.system('dvips -o images.ps images.dvi')
         if rc: return rc, None
         return gspdfpng.GSPDFPNG.executeConverter(self, open('images.ps'))

--- a/plasTeX/Imagers/gsdvipng.py
+++ b/plasTeX/Imagers/gsdvipng.py
@@ -10,7 +10,7 @@ if sys.platform.startswith('win'):
 class GSDVIPNG(gspdfpng.GSPDFPNG):
     """ Imager that uses gs to convert dvi to png """
     compiler = 'latex'
-    verification = '(%s --help && dvips --help)' % gs
+    verifications = ['%s --help' % gs, 'dvips --help', 'latex --help']
 
     def executeConverter(self, output):
         open('images.dvi', 'w').write(output.read())

--- a/plasTeX/Imagers/pdf2svg.py
+++ b/plasTeX/Imagers/pdf2svg.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+from plasTeX.Imagers import VectorImager
+
+class PDFSVG(VectorImager):
+    """ Imager that uses pdf2svg """
+    fileExtension = '.svg'
+    verifications = ['pdflatex --help', 'which pdf2svg', 'pdfcrop --help']
+    compiler = 'pdflatex'
+
+    def executeConverter(self, output):
+        open('images-uncropped.pdf', 'wb').write(output.read())
+        subprocess.call(["pdfcrop", "images-uncropped.pdf", "images.pdf"], stdout=subprocess.PIPE)
+
+        rc = 0
+        page = 1
+        while 1:
+            filename = 'img%d.svg' % page
+            rc = subprocess.call(['pdf2svg', 'images.pdf', filename, str(page)], stdout=subprocess.PIPE)
+            if rc:
+                break
+
+            if not open(filename).read().strip():
+                os.remove(filename)
+                break
+            page += 1
+            if page > len(self.images):
+                break
+        return rc, None
+
+Imager = PDFSVG

--- a/plasTeX/Imagers/pdf2svg.py
+++ b/plasTeX/Imagers/pdf2svg.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import subprocess
 import re
 import xml.etree.ElementTree as ET
+from typing import List, Tuple, Optional
 from plasTeX.Imagers import VectorImager
 
 length_re = re.compile('([0-9\\.]*)(.*)')
@@ -13,7 +14,7 @@ class PDFSVG(VectorImager):
     verifications = ['pdflatex --help', 'which pdf2svg', 'pdfcrop --help']
     compiler = 'pdflatex'
 
-    def executeConverter(self, output):
+    def executeConverter(self, output: bytes) -> Tuple[int, Optional[List[str]]]:
         Path("images-uncropped.pdf").write_bytes(output)
 
         subprocess.call(["pdfcrop", "images-uncropped.pdf", "images.pdf"], stdout=subprocess.DEVNULL)

--- a/plasTeX/Imagers/pdf2svg.py
+++ b/plasTeX/Imagers/pdf2svg.py
@@ -11,7 +11,7 @@ class PDFSVG(VectorImager):
     compiler = 'pdflatex'
 
     def executeConverter(self, output):
-        open('images-uncropped.pdf', 'wb').write(output.read())
+        open('images-uncropped.pdf', 'wb').write(output)
         subprocess.call(["pdfcrop", "images-uncropped.pdf", "images.pdf"], stdout=subprocess.PIPE)
 
         rc = 0

--- a/plasTeX/Imagers/pdf2svg.py
+++ b/plasTeX/Imagers/pdf2svg.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from pathlib import Path
 import subprocess
 import re
 import xml.etree.ElementTree as ET
@@ -13,12 +14,12 @@ class PDFSVG(VectorImager):
     compiler = 'pdflatex'
 
     def executeConverter(self, output):
-        open('images-uncropped.pdf', 'wb').write(output)
+        Path("images-uncropped.pdf").write_bytes(output)
+
         subprocess.call(["pdfcrop", "images-uncropped.pdf", "images.pdf"], stdout=subprocess.DEVNULL)
 
         rc = 0
-        page = 1
-        while 1:
+        for page in range(1, len(self.images) + 1):
             filename = 'img%d.svg' % page
             rc = subprocess.call(['pdf2svg', 'images.pdf', filename, str(page)], stdout=subprocess.DEVNULL)
             if rc:
@@ -29,18 +30,12 @@ class PDFSVG(VectorImager):
                 tree = ET.parse(filename)
                 root = tree.getroot()
 
-                width = length_re.match(root.attrib["width"])
-                root.attrib["width"] = "{}{}".format(float(width.group(1)) * scale, width.group(2))
-
-                height = length_re.match(root.attrib["height"])
-                root.attrib["height"] = "{}{}".format(float(height.group(1)) * scale, height.group(2))
+                for attrib in ["width", "height"]:
+                    m = length_re.match(root.attrib[attrib])
+                    root.attrib[attrib] = "{}{}".format(float(m.group(1)) * scale, m.group(2))
 
                 tree.write(filename)
 
-
-            page += 1
-            if page > len(self.images):
-                break
         return rc, None
 
 Imager = PDFSVG

--- a/plasTeX/Imagers/pdf2svg.py
+++ b/plasTeX/Imagers/pdf2svg.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
-import os
 import subprocess
+import re
+import xml.etree.ElementTree as ET
 from plasTeX.Imagers import VectorImager
 
+length_re = re.compile('([0-9\\.]*)(.*)')
 class PDFSVG(VectorImager):
     """ Imager that uses pdf2svg """
     fileExtension = '.svg'
@@ -12,19 +14,30 @@ class PDFSVG(VectorImager):
 
     def executeConverter(self, output):
         open('images-uncropped.pdf', 'wb').write(output)
-        subprocess.call(["pdfcrop", "images-uncropped.pdf", "images.pdf"], stdout=subprocess.PIPE)
+        subprocess.call(["pdfcrop", "images-uncropped.pdf", "images.pdf"], stdout=subprocess.DEVNULL)
 
         rc = 0
         page = 1
         while 1:
             filename = 'img%d.svg' % page
-            rc = subprocess.call(['pdf2svg', 'images.pdf', filename, str(page)], stdout=subprocess.PIPE)
+            rc = subprocess.call(['pdf2svg', 'images.pdf', filename, str(page)], stdout=subprocess.DEVNULL)
             if rc:
                 break
 
-            if not open(filename).read().strip():
-                os.remove(filename)
-                break
+            scale = self.config["images"]["scale-factor"]
+            if scale != 1:
+                tree = ET.parse(filename)
+                root = tree.getroot()
+
+                width = length_re.match(root.attrib["width"])
+                root.attrib["width"] = "{}{}".format(float(width.group(1)) * scale, width.group(2))
+
+                height = length_re.match(root.attrib["height"])
+                root.attrib["height"] = "{}{}".format(float(height.group(1)) * scale, height.group(2))
+
+                tree.write(filename)
+
+
             page += 1
             if page > len(self.images):
                 break

--- a/plasTeX/Imagers/pdftoppm.py
+++ b/plasTeX/Imagers/pdftoppm.py
@@ -35,7 +35,7 @@ class pdftoppm(_Imager):
         list of images.
 
         """
-        open('images.out', 'wb').write(output.read())
+        open('images.out', 'wb').write(output)
         options = ''
         if self._configOptions:
             for opt, value in self._configOptions:

--- a/plasTeX/Renderers/__init__.py
+++ b/plasTeX/Renderers/__init__.py
@@ -472,6 +472,8 @@ class Renderer(dict):
                 break
             elif name == 'dvisvgm':
                 from plasTeX.Imagers.dvisvgm import Imager as VectorImager
+            elif name == 'pdf2svg':
+                from plasTeX.Imagers.pdf2svg import Imager as VectorImager
             else:
                 log.warning("Invalid imager '%s'")
                 continue


### PR DESCRIPTION
Currently this uses pdfcrop to crop the pdf before converting it to svg.
I've been unable to find a straightforward way to crop svg's; something
we should probably look into in the future (the Image.crop function
doesn't work on svg's. We should fix that).

The resulting svg's are much smaller than that of dvisvgm, but this is configurable via the scale factor