### PR TITLE
Backport some fixes from gerby-project

### DIFF
--- a/plasTeX/Base/LaTeX/Definitions.py
+++ b/plasTeX/Base/LaTeX/Definitions.py
@@ -86,11 +86,11 @@ class newtheorem(Command):
         if attrs['*modifier*']:
             newclass = type(str(name), (Environment,),
                     {'caption': caption, 'nodeName': 'thmenv', 'thmName': name,
-                        'args': '[title]'})
+                        'args': '[title]', 'forcePars': True})
         else:
             newclass = type(str(name), (Environment,),
                     {'caption': caption, 'nodeName': 'thmenv', 'thmName': name,
-                        'counter': counter, 'args': '[title]'})
+                        'counter': counter, 'args': '[title]', 'forcePars': True})
         self.ownerDocument.context.addGlobal(name, newclass)
 
 

--- a/plasTeX/Base/LaTeX/Definitions.py
+++ b/plasTeX/Base/LaTeX/Definitions.py
@@ -95,6 +95,7 @@ class newtheorem(Command):
 
 
 class proof(Environment):
+    blockType = True
     args ='[caption]'
 
     def digest(self, tokens):

--- a/unittests/Proof.py
+++ b/unittests/Proof.py
@@ -1,0 +1,48 @@
+from plasTeX.TeX import TeX
+
+def test_proof_in_par():
+    """Check proof environment ends the current paragraph."""
+    tex = TeX()
+    tex.input(r'''
+      \documentclass{article}
+      \begin{document}
+
+      a
+      \begin{proof}
+      b
+      \end{proof}
+      c
+
+      \end{document}
+      ''')
+    doc = tex.parse()
+    proof = doc.getElementsByTagName('proof')[0]
+    if len(proof.parentNode.childNodes) != 1:
+        print(doc.toXML())
+        assert False
+
+def test_proof_block_type():
+    """
+    Check proof environment ends up inside a blockType paragraph. This in
+    particular makes HTML5 not wrap the resulting object in <p></p> tags.
+    """
+    tex = TeX()
+    tex.input(r'''
+      \documentclass{article}
+      \begin{document}
+
+      a
+
+      \begin{proof}
+      b
+      \end{proof}
+
+      c
+
+      \end{document}
+      ''')
+    doc = tex.parse()
+    proof = doc.getElementsByTagName('proof')[0]
+    if not proof.parentNode.blockType:
+        print(doc.toXML())
+        assert False

--- a/unittests/Theorem.py
+++ b/unittests/Theorem.py
@@ -1,0 +1,15 @@
+from plasTeX.TeX import TeX
+from plasTeX.Base.TeX.Primitives import par
+
+def test_single_paragraph_theorem():
+    """Check single paragraph theorem does contain a paragraph"""
+    tex = TeX()
+    tex.input(r'''
+      \newtheorem{thm}{Theorem}
+      \begin{thm}
+      a b c
+      \end{thm}
+      ''')
+    nodes = tex.parse().getElementsByTagName('thm')[0].childNodes
+    assert len(nodes) == 1
+    assert isinstance(nodes[0], par)


### PR DESCRIPTION
The first commit fixes spacing issues when the theorem content only has one paragraph.

The second commit marks `proof` as `blockType`.