### PR TITLE
Fix `Macro.source` for non-letter commands

### DIFF
--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -421,7 +421,8 @@ class Macro(Element):
         argSource = sourceArguments(self)
         if not argSource:
             argSource = ' '
-        elif argSource[0] in encoding.stringletters():
+        elif argSource[0] in encoding.stringletters() and\
+             not (len(self.macroName) == 1 and self.macroName[0] not in encoding.stringletters()):
             argSource = ' %s' % argSource
         s = '%s%s%s' % (escape, name, argSource)
 

--- a/unittests/accents.py
+++ b/unittests/accents.py
@@ -1,0 +1,8 @@
+from plasTeX.TeX import TeX
+
+def test_accent():
+    input_data = r'\"o'
+    tex = TeX()
+    tex.input(input_data)
+    node = tex.parse()[0]
+    assert node.source == input_data


### PR DESCRIPTION
If a command name comprises of a single non-letter, then there should
not be a space between the command and the argument because the command
is necessarily one character long.

One can test this with $\text{\"o}$ using the HTML5 renderer.

This is fix is not entirely ideal. In theory, we should decide if the name is a non-letter during parsing. However, `EscapeSequence` transitively inherits `str`, and hence is immutable, so we cannot record this information. In general, we really should just remember what the source is during parsing, instead of trying to second guess it based on the parsed result.