### PR TITLE
Deal with latex failures

### DIFF
--- a/plasTeX/Imagers/__init__.py
+++ b/plasTeX/Imagers/__init__.py
@@ -621,6 +621,7 @@ class Imager(object):
         p = subprocess.Popen(shlex.split(cmd),
                      stdout=subprocess.PIPE,
                      stderr=subprocess.STDOUT,
+                     stdin=subprocess.DEVNULL,
                      universal_newlines=True)
         cmd_line = '{} {}{}images.tex'.format(program, tempdir, os.sep)
         while True:

--- a/unittests/LaTeXError.py
+++ b/unittests/LaTeXError.py
@@ -1,0 +1,34 @@
+import os, subprocess
+from pathlib import Path
+
+def test_latex_imager_failure(tmpdir, pytestconfig):
+    """While rendering using LaTeX in an imager, a missing package shouldn't
+    block plasTeX."""
+    tmpdir = Path(str(tmpdir))
+
+    (tmpdir / "CustomRenderer").mkdir()
+    (tmpdir / "CustomRenderer" / "__init__.py").write_text(r"""
+from plasTeX.Renderers import Renderer as BaseRenderer
+
+class Renderer(BaseRenderer):
+    def  __init__(self, *args, **kwargs):
+        BaseRenderer.__init__(self, *args, **kwargs)
+        self["document"] = lambda x: x.image.url
+    """)
+
+    (tmpdir/'test.tex').write_text(r"""
+    \documentclass{article}
+    \usepackage{nonexistentpackage}
+    \begin{document}
+    \end{document}""")
+
+    cwd = os.getcwd()
+    os.chdir(str(tmpdir))
+
+    capmanager = pytestconfig.pluginmanager.getplugin('capturemanager')
+    capmanager.suspend_global_capture(in_=True)
+
+    proc = subprocess.run(['plastex', '--renderer=CustomRenderer', 'test.tex'], timeout=3, check=False)
+
+    capmanager.resume_global_capture()
+    os.chdir(cwd)


### PR DESCRIPTION
Fixes #139. This causes plastex to not hang/wait for user input if
`latex` fails when called by the imager.

Adding a test for this turns out to be very tricky, since pytest seems
to automatically redirect stdin to /dev/null , so I cannot reproduce the
error. Someone more knowledgable about pytest might be able to fix this,
but otherwise I'll leave this as is.