### PR TITLE
Update default HTML5 MathJax url

### DIFF
--- a/plasTeX/Renderers/HTML5/Config.py
+++ b/plasTeX/Renderers/HTML5/Config.py
@@ -75,7 +75,7 @@ section['mathjax-url'] = StringOption(
     """ Url of the MathJax lib """,
     options='--mathjax-url',
     category='html5',
-    default='http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_CHTML',
+    default='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js?config=TeX-AMS_CHTML',
 )
 
 section['mathjax-dollars'] = BooleanOption(


### PR DESCRIPTION
The existing default MathJax url redirects us to the new default url,
except it hardcodes version 2.7.1 whereas the new default always points
to latest, cf #170