### PR TITLE
Remove bs4 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Jinja2>=2.10.1
 Unidecode>=0.4.21
-beautifulsoup4>=4.6.0
 Pillow>=7

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,5 @@ setup(name="plasTeX",
          'plasTeX.Renderers.S5.Themes.default.ui.default': templates+styles+images,
       },
       scripts=['plasTeX/plastex'],
-      install_requires=['Jinja2>=2.10.1', 'Unidecode>=0.4.21',
-              'beautifulsoup4>=4.6.0', 'Pillow>=7']
+      install_requires=['Jinja2>=2.10.1', 'Unidecode>=0.4.21', 'Pillow>=7']
 )


### PR DESCRIPTION
This was previously used for the tikz renderer which has now been
replaced. It is still in requirements_tests.txt since it is needed for
`unittests/Packages/conftest.py`