### PR TITLE
Make \let less broken

### DIFF
--- a/plasTeX/Context.py
+++ b/plasTeX/Context.py
@@ -2,6 +2,7 @@
 
 from plasTeX import ismacro, macroName
 from plasTeX.Logging import getLogger
+from plasTeX.Base.TeX.Primitives import relax
 from plasTeX.Tokenizer import Tokenizer, Token, DEFAULT_CATEGORIES, VERBATIM_CATEGORIES
 import os
 import configparser
@@ -938,7 +939,7 @@ class Context(object):
         """
         # Macro already exists
         if name in list(self.keys()):
-            if not issubclass(self[name], (plasTeX.NewCommand, plasTeX.Definition)):
+            if not issubclass(self[name], (plasTeX.NewCommand, plasTeX.Definition, relax)):
                 if not issubclass(self[name], plasTeX.TheCounter):
                     return
             macrolog.debug('redefining command "%s"', name)
@@ -1064,9 +1065,7 @@ class Context(object):
             c.let('bgroup', BeginGroup('{'))
 
         """
-        if source.catcode == Token.CC_ESCAPE and source.macroName == "relax":
-            del self.top[dest.macroName]
-        elif source.catcode == Token.CC_ESCAPE:
+        if source.catcode == Token.CC_ESCAPE:
             self.top[dest.macroName] = self[source.macroName]
         else:
             self.top.lets[dest.macroName] = source

--- a/plasTeX/Tokenizer.py
+++ b/plasTeX/Tokenizer.py
@@ -471,7 +471,7 @@ class Tokenizer(object):
                 else: token = EscapeSequence()
 
                 # Check for any \let aliases
-                token = context.lets.get(token, token)
+                token = context.get_let(token)
 
                 # TODO: This action should be generalized so that the
                 #       tokens are processed recursively
@@ -489,7 +489,7 @@ class Tokenizer(object):
 
             elif code == CC_ACTIVE:
                 token = EscapeSequence('active::%s' % token)
-                token = context.lets.get(token, token)
+                token = context.get_let(token)
                 self.state = STATE_M
 
             else:

--- a/unittests/Let.py
+++ b/unittests/Let.py
@@ -1,0 +1,45 @@
+from plasTeX.TeX import TeX
+
+def test_let_redef():
+    tex = TeX()
+    tex.input(r'''
+\newcommand\foo{a}
+\let\bar\foo
+\renewcommand\foo{b}
+\bar
+''')
+    assert tex.parse().textContent.strip() == "a"
+
+def test_let_nonrecursive():
+    tex = TeX()
+    tex.input(r'''
+\newcommand\foo{a}
+\newcommand\fooo{\foo}
+\let\bar\fooo
+\renewcommand\foo{b}
+\bar
+''')
+    assert tex.parse().textContent.strip() == "b"
+
+def test_let_recursive():
+    tex = TeX()
+    tex.input(r'''
+\newcommand\foo{a}
+\let\fooo\foo
+\let\bar\fooo
+\renewcommand\foo{b}
+\bar
+''')
+    assert tex.parse().textContent.strip() == "a"
+
+def test_let_scope():
+    tex = TeX()
+    tex.input(r'''
+{
+   \let\foo=a
+   \foo%
+}%
+\let\foo=b%
+\foo
+''')
+    assert tex.parse().textContent.strip() == "ab"


### PR DESCRIPTION
This is still somewhat broken but less broken.

I believe this works correctly if we \let\foo\bar where \foo and \bar
are both escape sequences.

The correct behaviour for \let\foo=x seems to be extremely complicated
when x is not an escape sequence. For example, if we set \let\foo={,
then apparently \foo can sometimes take the role of { but not always.
Currently, we simply replace \foo with { in the Tokenizer in this case
(which was the previous behaviour for *all* \let definitions). This is
incorrect but just as wrong as the previous version.

One particular problem with this is that we cannot use let twice, i.e.

\let\foo=a
\let\foo=b

fails to define \foo as b, as the second line gets turned into \let a=b.
This is not something special about let. This is the same "\foo is
sometimes `a` but not always" problem.

Without the commit, the first, third and fourth tests fail. The second
test passes but only by coincidence.