### PR TITLE
Fix counter presentation

### DIFF
--- a/plasTeX/Context.py
+++ b/plasTeX/Context.py
@@ -779,7 +779,7 @@ class Context(object):
         """
         self.contexts[-1].categories = self.categories = VERBATIM_CATEGORIES[:]
 
-    def newcounter(self, name, resetby=None, initial=0, format=None):
+    def newcounter(self, name, resetby=None, initial=0, format=None, trimLeft = False):
         """
         Create a new counter
 
@@ -804,7 +804,7 @@ class Context(object):
         if format is None:
             format = '${%s}' % name
         newclass = type('the' + name, (plasTeX.TheCounter,),
-                               {'format': format})
+                {'format': format, 'trimLeft': trimLeft})
         self.addGlobal('the' + name, newclass)
 
     def newwrite(self, name, file):

--- a/plasTeX/Packages/book.py
+++ b/plasTeX/Packages/book.py
@@ -37,9 +37,9 @@ def ProcessOptions(options, document):
 
     # Floats
     context.newcounter('figure', resetby='chapter',
-                       format='${thechapter}.${figure}')
+                       format='${thechapter}.${figure}', trimLeft=True)
     context.newcounter('table', resetby='chapter',
-                       format='${thechapter}.${table}')
+                       format='${thechapter}.${table}', trimLeft=True)
     context.newcounter('topnumber')
     context.newcounter('bottomnumber')
     context.newcounter('totalnumber')

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -1613,6 +1613,7 @@ class Counter(object):
 class TheCounter(Command):
     """ Base class for \\thecounter commands """
     format = None
+    trimLeft = False
 
     def invoke(self, tex):
 
@@ -1637,11 +1638,11 @@ class TheCounter(Command):
 
         t = re.sub(r'\$\{\s*(\w+)(?:\.(\w+))?\s*\}', counterValue, format)
 
-        # This is kind of a hack.  Since number formats aren't quite as
-        # flexible as in LaTeX, we have to do somethings heuristically.
-        # In this case, whenever a counter value comes out as a zero,
-        # just hank it out.  This is especially useful in document classes
-        # such as book and report which do this in the \thefigure format macro.
-        t = re.sub(r'\b0[^\dA-Za-z]+', r'', t)
+        # If trimLeft is set to True, we remove any "0." at the beginning.
+        # Document classes such as book and report which do this in the
+        # \thefigure format macro.
+        if self.trimLeft:
+            while t.startswith("0."):
+                t = t[2:]
 
         return tex.textTokens(t)

--- a/unittests/Counter.py
+++ b/unittests/Counter.py
@@ -1,0 +1,20 @@
+
+from plasTeX.TeX import TeX
+
+def test_counter():
+    t = TeX()
+    t.input(r'''
+\documentclass{book}
+\begin{document}
+\begin{figure}\caption{A}\end{figure}
+\section{B}
+\chapter{C}
+\section{D}
+\begin{figure}\caption{E}\end{figure}
+\end{document}
+    ''')
+
+    p = t.parse()
+
+    assert [x.ref.source for x in p.getElementsByTagName("caption")] == ["1", "1.1"]
+    assert [x.ref.source for x in p.getElementsByTagName("section")] == ["0.1", "1.1"]


### PR DESCRIPTION
Previously, TheCounter yanks any counter value that is 0. This is the
desired behaviour in classes such as \thefigure in book or report, which
wants to convert Figure 0.1 to Figure 1. However, this is generally
undesirable. It turns subsection 0.1 to subsection 1, and even worse,
4.0.3 to 4.3.

This commit modifies the behaviour in two ways. Firstly, the yanking
behaviour is opt-in. Secondly, it only removes instances of "0." at the
beginning of the counter value, instead of everywhere.

Fixes #170