### PR TITLE
Removed Token classes that can never be initialized

### DIFF
--- a/plasTeX/DOM/__init__.py
+++ b/plasTeX/DOM/__init__.py
@@ -1746,16 +1746,6 @@ class Text(CharacterData):
         return self.parentNode.textContent
 
 
-class Comment(CharacterData):
-    """
-    Comment
-
-    http://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/core.html#ID-1728279322
-    """
-    nodeName = '#comment'
-    nodeType = Node.COMMENT_NODE
-    __slots__ = Node.TEXT_SLOTS
-
 
 class TypeInfo(object):
     """
@@ -2024,7 +2014,6 @@ class Document(Node):
     elementClass = Element
     documentFragmentClass = DocumentFragment
     textNodeClass = Text
-    commentClass = Comment
     cdataSectionClass = CDATASection
     processingInstructionClass = ProcessingInstruction
     attributeClass = Attr
@@ -2089,22 +2078,6 @@ class Document(Node):
 
         """
         o = self.textNodeClass(data)
-        o.ownerDocument = self
-        o.parentNode = None
-        return o
-
-    def createComment(self, data):
-        """
-        Instantiate a new comment node
-
-        Required Arguments:
-        data -- string to initialize the comment with
-
-        Returns:
-        new comment node
-
-        """
-        o = self.commentClass(data)
         o.ownerDocument = self
         o.parentNode = None
         return o

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -276,31 +276,6 @@ class TeX(object):
             except IndexError:
                 break
 
-    def iterchars(self):
-        """
-        Iterate over input characters (untokenized)
-
-        Returns:
-        generator that iterates through the untokenized characters
-
-        """
-        # Create locals before going into generator loop
-        inputs = self.inputs
-        context = self.ownerDocument.context
-        endInput = self.endInput
-        ownerDocument = self.ownerDocument
-
-        while inputs:
-            # Walk through characters
-            try:
-                for char in inputs[-1][0].iterchars():
-                    yield char
-                else:
-                    endInput()
-            # This really shouldn't happen, but just in case...
-            except IndexError:
-                break
-
     def __iter__(self):
         """
         Iterate over tokens while expanding them

--- a/plasTeX/Tokenizer.py
+++ b/plasTeX/Tokenizer.py
@@ -3,7 +3,7 @@
 from plasTeX.DOM import Node, Text
 from plasTeX import encoding
 from io import BytesIO, StringIO, TextIOWrapper
-from typing import Tuple, NewType
+from typing import Tuple, NewType, Optional, Callable, List, Generator
 
 # Default TeX categories
 DEFAULT_CATEGORIES = [
@@ -30,33 +30,33 @@ DEFAULT_CATEGORIES = [
 VERBATIM_CATEGORIES = [''] * 16
 VERBATIM_CATEGORIES[11] = encoding.stringletters()
 
-CategoryCode = NewType('CategoryCode', int)
+CatCode = NewType('CatCode', int)
 
 class Token(Text):
     """ Base class for all TeX tokens """
 
     # The 16 category codes defined by TeX
-    CC_ESCAPE = 0
-    CC_BGROUP = 1
-    CC_EGROUP = 2
-    CC_MATHSHIFT = 3
-    CC_ALIGNMENT = 4
-    CC_EOL = 5
-    CC_PARAMETER = 6
-    CC_SUPER = 7
-    CC_SUB = 8
-    CC_IGNORED = 9
-    CC_SPACE = 10
-    CC_LETTER = 11
-    CC_OTHER = 12
-    CC_ACTIVE = 13
-    CC_COMMENT = 14
-    CC_INVALID = 15
+    CC_ESCAPE = CatCode(0)
+    CC_BGROUP = CatCode(1)
+    CC_EGROUP = CatCode(2)
+    CC_MATHSHIFT = CatCode(3)
+    CC_ALIGNMENT = CatCode(4)
+    CC_EOL = CatCode(5)
+    CC_PARAMETER = CatCode(6)
+    CC_SUPER = CatCode(7)
+    CC_SUB = CatCode(8)
+    CC_IGNORED = CatCode(9)
+    CC_SPACE = CatCode(10)
+    CC_LETTER = CatCode(11)
+    CC_OTHER = CatCode(12)
+    CC_ACTIVE = CatCode(13)
+    CC_COMMENT = CatCode(14)
+    CC_INVALID = CatCode(15)
 
     TOKEN_SLOTS = __slots__ = Text.TEXT_SLOTS
 
-    catcode = None       # TeX category code
-    macroName = None     # Macro to invoke in place of this token
+    catcode = None       # type: Optional[CatCode] # TeX category code
+    macroName = None     # type: Optional[str] # Macro to invoke in place of this token
 
     def __repr__(self):
         return self.source
@@ -173,7 +173,7 @@ class Tokenizer(object):
     STATE_M = 2
     STATE_N = 4
 
-    tokenClasses = [None] * 16
+    tokenClasses = [None] * 16 # type: List[Optional[Callable]]
     tokenClasses[Token.CC_BGROUP] = BeginGroup
     tokenClasses[Token.CC_EGROUP] = EndGroup
     tokenClasses[Token.CC_MATHSHIFT] = MathShift
@@ -229,7 +229,7 @@ class Tokenizer(object):
             if not char or ord(char) == 10:
                 break
 
-    def iterchars(self) -> Tuple[CategoryCode, str]:
+    def iterchars(self) -> Generator[Tuple[CatCode, str], None, None]:
         """
         Get the next character in the stream and its category code
 

--- a/unittests/DOM/Document.py
+++ b/unittests/DOM/Document.py
@@ -23,12 +23,6 @@ class DocumentTest(TestCase):
         node = doc.createTextNode('foo')
         assert isinstance(node, Text)
         assert node == 'foo'
-    
-    def testCreateComment(self):
-        doc = Document()
-        node = doc.createComment('foo')
-        assert isinstance(node, Comment)
-        assert node == 'foo'
 
     def testCreateCDATASection(self):
         doc = Document()


### PR DESCRIPTION
They previously existed because Tokenizer.iterchars wanted to return
Token objects, but we can just return the catcode and character. From a
TeX point of view, an Active character is a valid token, but we decided
to encode them as special EscapeSequence's instead, so we can eliminate
the class as well.

The Tokenizer.iterchars function is only used in two places. The first
is the Tokenizer iteration function, which is modified accordingly. It
is also used in TeX.iterchars, which was introduced in cefff9c, but its
use was eliminated in b1d76f9. The function doesn't really make much
sense in the first place and I believe that is why we stopped using it.
I deleted this function completely.

This commit came from thinking about what we should do when someone tries to `\let` a command to be a comment character, e.g. `\let\foo=%`. Of course, this doesn't work, since `%` is thrown away by the Tokenizer so it never reaches the `\let` command. Removing these classes that can never exist emphasizes the fact that in a correct implementation of `\let`, we never have to worry receiving `Comment`.