### PR TITLE
Chapter counter shouldn't reset with new part

### DIFF
--- a/plasTeX/Packages/book.py
+++ b/plasTeX/Packages/book.py
@@ -13,7 +13,7 @@ def ProcessOptions(options, document):
     # Sections
     context.newcounter('part', resetby='volume',
                        format='$part')
-    context.newcounter('chapter', resetby='part',
+    context.newcounter('chapter', resetby='volume',
                        format='$chapter')
     context.newcounter('section', resetby='chapter',
                        format='${thechapter}.${section}')

--- a/unittests/Packages/Book.py
+++ b/unittests/Packages/Book.py
@@ -1,0 +1,15 @@
+from plasTeX.TeX import TeX
+
+def test_book_toc():
+    t = TeX()
+    t.input(r'''
+\documentclass{book}
+\begin{document}
+\chapter{A}
+\part{B}
+\chapter{C}
+\end{document}
+''')
+    p = t.parse()
+    print(p.getElementsByTagName("chapter"))
+    assert ['1', '2'] == [x.ref.source for x in p.getElementsByTagName("chapter")]


### PR DESCRIPTION
A MWE shows that this is not what happens in TeX.