### PR TITLE
Add option disable some charsubs

### DIFF
--- a/Doc/command.tex
+++ b/Doc/command.tex
@@ -148,6 +148,16 @@ table of contents.  By default, only sections that create files will show
 up in the table of contents.
 \end{configuration}
 
+\begin{configuration}{Disable character substitutions}
+\options{\longprogramopt{disable-charsub}}
+\config{document}{disable-charsub}
+specifies a ","-delimited list of characters not to perform character
+substitutions on. Character substitutions replace certain characters or groups
+of characters with typographically superior unicode versions, e.g.\ \code{`}
+with `. This may be unsuitable for certain use cases. For example, it may make
+search harder.
+\end{configuration}
+
 
 \subsection{Counters}
 

--- a/plasTeX/Config.py
+++ b/plasTeX/Config.py
@@ -384,6 +384,13 @@ doc['lang-terms'] = StringOption(
     default = '',
 )
 
+doc['disable-charsub'] = StringOption(
+    """Specifies a "," delimited list of characters to not perform character substitutions""",
+    options = "--disable-charsub",
+    category = "document",
+    default = ""
+)
+
 config.read('~/.plasTeXrc')
 config.read('/usr/local/etc/plasTeXrc')
 config.read(os.path.join(os.path.dirname(__file__), 'plasTeXrc'))

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -784,24 +784,16 @@ class TeXFragment(DocumentFragment):
 class TeXDocument(Document):
     """ TeX Document node """
     documentFragmentClass = TeXFragment
-    charsubs = [
-        ('``', chr(8220)),
-        ("''", chr(8221)),
-        ('"`', chr(8222)),
-        ('"\'', chr(8220)),
-        ('`', chr(8216)),
-        ("'", chr(8217)),
-        ('---', chr(8212)),
-        ('--', chr(8211)),
-#       ('fj', unichr(58290)),
-#       ('ff', unichr(64256)),
-#       ('fi', unichr(64257)),
-#       ('fl', unichr(64258)),
-#       ('ffi',unichr(64259)),
-#       ('ffl',unichr(64260)),
-#       ('ij', unichr(307)),
-#       ('IJ', unichr(308)),
-    ]
+    defaultCharsubs = [
+            ('``', chr(8220)),
+            ("''", chr(8221)),
+            ('"`', chr(8222)),
+            ('"\'', chr(8220)),
+            ('`', chr(8216)),
+            ("'", chr(8217)),
+            ('---', chr(8212)),
+            ('--', chr(8211)),
+        ]
 
     def __init__(self, *args, **kwargs):
         # super(TeXDocument, self).__init__(*args, **kwargs)
@@ -823,6 +815,8 @@ class TeXDocument(Document):
 
         self.packageResources = []
         self.rendererdata = dict()
+
+        self.charsubs = [x for x in TeXDocument.defaultCharsubs if x[0] not in self.config["document"]["disable-charsub"].split(",")]
 
     def addPackageResource(self, resource):
         """

--- a/unittests/CharSub.py
+++ b/unittests/CharSub.py
@@ -1,0 +1,24 @@
+from plasTeX.TeX import TeX
+from plasTeX import TeXDocument
+from plasTeX.Config import config as base_config
+
+def test_charsub():
+    config = base_config.copy()
+
+    doc = TeXDocument(config=config)
+    tex = TeX(doc)
+
+    p = tex.input(r'''{``'' '---}''').parse()[0]
+    p.paragraphs()
+    assert p.textContent == "“” ’—"
+
+def test_modify_charsub():
+    config = base_config.copy()
+    config["document"]["disable-charsub"] = "'"
+
+    doc = TeXDocument(config=config)
+    tex = TeX(doc)
+
+    p = tex.input(r'''{``'' '---}''').parse()[0]
+    p.paragraphs()
+    assert p.textContent == "“” '—"


### PR DESCRIPTION
It provides only marginal typographical benifits, and breaks search for
words with apostrophes.

Fixes gerby-project/plastex#37