### PR TITLE
Fix regression caused by fbb79a5. Fixes #192

### DIFF
--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -422,7 +422,7 @@ class Macro(Element):
         if not argSource:
             argSource = ' '
         elif argSource[0] in encoding.stringletters() and\
-             not (len(self.macroName) == 1 and self.macroName[0] not in encoding.stringletters()):
+             not (len(name) == 1 and name[0] not in encoding.stringletters()):
             argSource = ' %s' % argSource
         s = '%s%s%s' % (escape, name, argSource)
 

--- a/unittests/Source.py
+++ b/unittests/Source.py
@@ -32,6 +32,14 @@ class Source(TestCase):
         source = normalize(output.source)
         assert input == source, '"%s" != "%s"' % (input, source)
 
+    def testMathCal(self):
+        input = r'a $ \mathcal A $ b'
+        s = TeX()
+        s.input(input)
+        output = s.parse()
+        source = normalize(output.source)
+        assert input == source, '"%s" != "%s"' % (input, source)
+
     def testDisplayMath(self):
         input = r'a \[ x^{y_3} \]b'
         s = TeX()


### PR DESCRIPTION
macroName is not always defined; we should use nodeName which defaults
to the class name when macroName is not defined.