### PR TITLE
Don't use callback in filename

### DIFF
--- a/plasTeX/Config.py
+++ b/plasTeX/Config.py
@@ -190,22 +190,11 @@ files['log'] = BooleanOption(
     category = 'files',
 )
 
-def setFilename(data):
-    """ If there is only one filename specified, turn off splitting """
-    data = data.strip()
-    if ' ' in data:
-        return data
-    if '[' in data:
-        return data
-    files['split-level'] = -10
-    return data
-
 files['filename'] = StringOption(
     """ Template for output filenames """,
     options = '--filename',
     default = 'index [$id, sect$num(4)]',
     category = 'files',
-    callback = setFilename,
 )
 
 files['bad-chars'] = StringOption(

--- a/plasTeX/Filenames.py
+++ b/plasTeX/Filenames.py
@@ -84,6 +84,7 @@ class Filenames(object):
     def parseFilenames(self, spec):
         """ Parse and expand the filename string """
         # Normalize string before parsing
+        spec = spec.strip()
         spec = re.sub(r'\$(\w+)', r'${\1}', spec)
         spec = re.sub(r'\${\s*(\w+)\s*}', r'${\1}', spec)
         spec = re.sub(r'\}\(\s*(\d+)\s*\)', r'.\1}', spec)

--- a/plasTeX/Renderers/__init__.py
+++ b/plasTeX/Renderers/__init__.py
@@ -299,8 +299,7 @@ class Renderable(object):
             if not hasattr(self, 'config'):
                 return
 
-            level = getattr(self, 'splitlevel',
-                            self.config['files']['split-level'])
+            level = getattr(self, 'splitlevel', r.level)
 
             # If our level doesn't invoke a split, don't return a filename
             if self.level > level:
@@ -404,6 +403,11 @@ class Renderer(dict):
 
         """
         config = document.config
+
+        self.level = config["files"]["split-level"]
+        filenameTemplate = config["files"]["filename"].strip()
+        if ' ' not in filenameTemplate and '[' not in filenameTemplate:
+            self.level = -10
 
         # If there are no keys, print a warning.
         # This is most likely a problem.


### PR DESCRIPTION
This makes it easier to migrate away from ConfigManager. The other
callbacks are more involved and are more easily replaced when we change
our config manager.