### PR TITLE
Fix imager test

### DIFF
--- a/unittests/imagers/imagers.py
+++ b/unittests/imagers/imagers.py
@@ -39,7 +39,7 @@ def test_imager(imager_tuple, tmpdir):
     tex = TeX()
     tex.ownerDocument.config['images'][kind] = imager
     if compiler is not None:
-        tex.ownerDocument.config['images']["compiler"] = compiler
+        tex.ownerDocument.config['images'][kind.replace("imager", "compiler")] = compiler
 
     tex.input(r'''
     \documentclass{article}


### PR DESCRIPTION
This is an obscure bug. It fails only when you run
```shell
pytest -k lualatex
```
(or xelatex), but not if you run the whole test suit.

It is clear why it fails - by setting the compiler, both the vector and
raster imager use the specified compiler. lualatex and xelatex
produce pdf files instead of dvi files, so the default raster imager
dvipng fails when attempting to convert the dvi to png.

The mysterious part is why this doesn't fail when we run all tests
together.