### PR TITLE
Don't always generate bitmap images

### DIFF
--- a/Doc/renderer-api.tex
+++ b/Doc/renderer-api.tex
@@ -92,6 +92,15 @@ which aren't capable of displaying equations, \LaTeX\ pictures, etc. such
 as HTML.
 \end{memberdesc}
 
+\begin{memberdesc}[Renderer]{vectorBitmap}
+a boolean indicating whether bitmap versions should be generated for vector
+images. The bitmap version is used to read off the height, width and depth of
+the image. If such information is not used by the renderer, we can skip
+producing the bitmap, which may take a long time.
+
+This defaults to \code{True}.
+\end{memberdesc}
+
 \begin{memberdesc}[Renderer]{imageTypes}
 contains a list of file extensions of valid image types for the renderer.
 The first element in the list is the default image format.  This format

--- a/Doc/renderers.tex
+++ b/Doc/renderers.tex
@@ -476,25 +476,22 @@ See the \class{Imager} API documentation for more information (see
 \subsection{Generating Vector Images}
 
 If you have a vector imager configured (such as dvisvg or dvisvgm), you
-can generate a vector version of the requested image as well as a 
-bitmap.  The nice thing about vector versions of images is that they
-can scale infinitely and not loose resolution.  The bad thing about them
-is that they are not as well supported in the real world as bitmaps.
+can generate a vector version of the requested image. The nice thing about
+vector versions of images is that they can scale infinitely and not loose
+resolution.
 
 Generating a vector image is just as easy as generating a bitmap image,
 you simply access the \member{vectorImage} property of the node that
 you want an image of.  This will return an \class{plasTeX.Imagers.Image} 
-instance that corresponds to the vector image.  A bitmap version of 
-the same image can be accessed through the \member{image} property of the
-document node or the \member{bitmap} variable of the vector image object.
+instance that corresponds to the vector image.
 
 Everything that was described about generating images in the previous 
 section is also true of vector images with the exception of cropping.
 \plasTeX\ does not attempt to crop vector images.  The program that
 converts the \LaTeX\ output to a vector image is expected to crop the 
-image down to the image content.  \plasTeX\ uses the information from
-the bitmap version of the image to determine the proper depth of the 
-vector image.
+image down to the image content.  Depending on the renderer configuration, a
+bitmap may be generated to determine the proper height, width and depth of
+the vector image.
 
 
 \subsection{Static Images}

--- a/plasTeX/Renderers/HTML5/__init__.py
+++ b/plasTeX/Renderers/HTML5/__init__.py
@@ -14,6 +14,7 @@ class HTML5(_Renderer):
     fileExtension = '.html'
     imageTypes = ['.svg', '.png','.jpg','.jpeg','.gif']
     vectorImageTypes = ['.svg']
+    vectorBitmap = False
 
     def loadTemplates(self, document):
         """Load templates as in PageTemplate but also look for packages that

--- a/plasTeX/Renderers/__init__.py
+++ b/plasTeX/Renderers/__init__.py
@@ -229,7 +229,8 @@ class Renderable(object):
     def vectorImage(self):
         """ Generate a vector image and return the image filename """
         image = Node.renderer.vectorImager.getImage(self)
-        image.bitmap = Node.renderer.imager.getImage(self)
+        if Node.renderer.vectorBitmap:
+            image.bitmap = Node.renderer.imager.getImage(self)
         return image
 
     @property
@@ -353,6 +354,7 @@ class Renderer(dict):
     textDefault = str
     default = str
     outputType = str
+    vectorBitmap = True
     imageTypes = []
     vectorImageTypes = []
     fileExtension = ''

--- a/unittests/imagers/disable_bitmap.py
+++ b/unittests/imagers/disable_bitmap.py
@@ -1,0 +1,35 @@
+import pytest
+
+from plasTeX.Renderers import Renderer
+from plasTeX.TeX import TeX
+from plasTeX.Imagers import Imager
+
+class NullImager(Imager):
+    def getImage(self, node):
+        raise ValueError
+
+@pytest.mark.parametrize('enable_bitmap', [True, False])
+def test_imager(enable_bitmap, tmpdir):
+    with tmpdir.as_cwd():
+        tex = TeX()
+        tex.ownerDocument.config['images']["imager"] = "none"
+        tex.ownerDocument.config['images']["vector-imager"] = "pdf2svg"
+
+        tex.input(r'''
+        \documentclass{article}
+        \begin{document}
+        $a + b = x$
+        \end{document}
+        ''')
+
+        doc = tex.parse()
+        renderer = Renderer()
+        renderer.imager = NullImager(doc)
+        renderer.vectorBitmap = enable_bitmap
+        renderer['math'] = lambda node: node.vectorImage.url
+
+        if enable_bitmap:
+            with pytest.raises(ValueError):
+                renderer.render(doc)
+        else:
+            renderer.render(doc)


### PR DESCRIPTION
Currently, if one requests a VectorImage from the imager, a bitmap image
is also produced to read off the desired height and width. These
properties are not used in certain renderers such as HTML5. Moreover,
producing these bitmaps is extremely slow.

This commit allows renderers to decide whether they want these bitmaps
to be produced, and disables it for HTML5.