### PR TITLE
Fix nested if

### DIFF
--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -557,10 +557,9 @@ class TeX(object):
                 cases[-1].append(t)
                 nesting += 1
             elif name == 'fi':
-                if nesting > 1:
-                    cases[-1].append(t)
-                elif not nesting:
+                if not nesting:
                     break
+                cases[-1].append(t)
                 nesting -= 1
             elif not(nesting) and name == 'else':
                 cases.append([])

--- a/unittests/If.py
+++ b/unittests/If.py
@@ -77,10 +77,10 @@ class TestIfs(TestCase):
         compare_output(r'\ifcase 2 bye\or text\or one\else two\fi')
 
     def testNestedIf(self):
-        compare_output(r'\ifnum 2 < 3 bye\iftrue text\ifcat() hi\fi\else one\fi\fi')
+        compare_output(r'\ifnum 2 < 3 bye\iftrue text\ifcat() hi\fi\else one\fi\fi foo')
 
     def testNestedIf2(self):
-        compare_output(r'\ifnum 2 > 3 bye\iftrue text\ifcat() hi\fi\else one\fi\fi')
+        compare_output(r'\ifnum 2 > 3 bye\iftrue text\ifcat() hi\fi\else one\fi\fi foo')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously, the `foo` at the end of the tests would not appear
