### PR TITLE
Don't insert \input command after parsing

### DIFF
--- a/plasTeX/Base/TeX/Primitives.py
+++ b/plasTeX/Base/TeX/Primitives.py
@@ -416,6 +416,7 @@ class input(Command):
         except (OSError, IOError) as msg:
             log.warning(msg)
             status.info(' ) ')
+        return []
 
 class endinput(Command):
     def invoke(self, tex):


### PR DESCRIPTION
If we leave the \input command, both the \input command and the input
content are in the source. If this is in the preamble, the imager's
compiler would run the content twice, which results in an error.

See also #179
