### PR TITLE
Use tempfile to name the Imager's temporary LaTeX source file

### DIFF
--- a/plasTeX/Imagers/__init__.py
+++ b/plasTeX/Imagers/__init__.py
@@ -441,6 +441,9 @@ class Imager(object):
     # The compiler command used to compile the LaTeX document
     compiler = 'latex'
 
+    # The filename for temporary LaTeX source
+    tmpFile = Path('images.tex')
+
     # Verification command to determine if the imager is available
     verifications = []
 
@@ -604,7 +607,9 @@ width 2pt\hskip2pt}}{}
 
         # Compile LaTeX source, then convert the output
         self.source.seek(0)
-        Path("images.tex").write_text(self.source.read(), encoding=self.config['files']['input-encoding'])
+        (_, fname) = tempfile.mkstemp('.tex', 'images-', '.', True)
+        self.tmpFile = Path(fname)
+        self.tmpFile.write_text(self.source.read(), encoding=self.config['files']['input-encoding'])
 
         def on_error(e):
             log.warning("Source files are saved at {}.".format(tempdir))
@@ -681,12 +686,12 @@ width 2pt\hskip2pt}}{}
 
     def compileLatex(self):
         """
-        Compile the LaTeX source, located at `images.tex`
+        Compile the LaTeX source, located at self.tmpFile
 
         This should raise an exception if the compilation fails.
         """
 
-        run_command(r'%s images.tex' % self.getCompiler())
+        run_command(r'%s %s' % (self.getCompiler(), self.tmpFile.name))
 
     def executeConverter(self, outfile: Optional[str] = None) -> List[Tuple[str, str]]:
         """
@@ -709,8 +714,8 @@ width 2pt\hskip2pt}}{}
         """
         if outfile is None:
             for ext in ['.dvi', ".pdf", ".ps"]:
-                if Path("images" + ext).is_file():
-                    outfile = "images" + ext
+                if self.tmpFile.with_suffix(ext).is_file():
+                    outfile = self.tmpFile.with_suffix(ext).name
                     break
 
         if outfile is None:

--- a/plasTeX/Imagers/dvisvgm.py
+++ b/plasTeX/Imagers/dvisvgm.py
@@ -13,7 +13,7 @@ class DVISVGM(_Imager):
 
     def executeConverter(self, outfile=None) -> List[Tuple[str, str]]:
         if outfile is None:
-            outfile = "images.dvi"
+            outfile = self.tmpFile.with_suffix('.dvi').name
 
         scale = self.config["images"]["scale-factor"]
 

--- a/plasTeX/Imagers/gsdvipng.py
+++ b/plasTeX/Imagers/gsdvipng.py
@@ -14,9 +14,9 @@ class GSDVIPNG(gspdfpng.GSPDFPNG):
 
     def executeConverter(self, outfile=None):
         if outfile is None:
-            outfile = 'images.dvi'
+            outfile = self.tmpFile.with_suffix('.dvi').name
 
-        subprocess.run(['dvips', '-o', "images.ps", outfile], check=True)
-        return gspdfpng.GSPDFPNG.executeConverter(self, "images.ps")
+        subprocess.run(['dvips', '-o', self.tmpFile.with_suffix('.ps').name, outfile], check=True)
+        return gspdfpng.GSPDFPNG.executeConverter(self, self.tmpFile.with_suffix('.ps').name)
 
 Imager = GSDVIPNG

--- a/plasTeX/Imagers/pdf2svg.py
+++ b/plasTeX/Imagers/pdf2svg.py
@@ -15,9 +15,9 @@ class PDFSVG(VectorImager):
 
     def executeConverter(self, outfile=None) -> List[Tuple[str, str]]:
         if outfile is None:
-            outfile = "images.pdf"
+            outfile = self.tmpFile.with_suffix('.pdf').name
 
-        subprocess.call(["pdfcrop", outfile, "images-cropped.pdf"], stdout=subprocess.DEVNULL)
+        subprocess.call(["pdfcrop", outfile, self.tmpFile.with_suffix('.cropped.pdf').name], stdout=subprocess.DEVNULL)
 
         scale = self.config["images"]["scale-factor"]
 
@@ -27,7 +27,7 @@ class PDFSVG(VectorImager):
             page, output = line.split(",")
             images.append((filename, output.rstrip()))
 
-            subprocess.run(['pdf2svg', 'images-cropped.pdf', filename, str(page)], stdout=subprocess.DEVNULL, check=True)
+            subprocess.run(['pdf2svg', self.tmpFile.with_suffix('.cropped.pdf').name, filename, str(page)], stdout=subprocess.DEVNULL, check=True)
 
             if scale != 1:
                 tree = ET.parse(filename)

--- a/plasTeX/Imagers/pdftoppm.py
+++ b/plasTeX/Imagers/pdftoppm.py
@@ -35,7 +35,7 @@ class pdftoppm(_Imager):
 
         """
         if outfile is None:
-            outfile = "images.pdf"
+            outfile = self.tmpFile.with_suffix('.pdf')
 
         options = ''
         if self._configOptions:


### PR DESCRIPTION
This replaces using the filename `image.tex` with a temporary one from `tempfile.mkstemp` when the Imager is used. This avoids a problem with filename collision when a source input file is named `images.tex`.