### PR TITLE
fix double dollar construction rendering

### DIFF
--- a/plasTeX/Base/TeX/Primitives.py
+++ b/plasTeX/Base/TeX/Primitives.py
@@ -78,7 +78,11 @@ class MathShift(Command):
         current = self.ownerDocument.createElement('math')
         for t in tex.itertokens():
             if t.catcode == Token.CC_MATHSHIFT:
-                current = self.ownerDocument.createElement('displaymath')
+                # Case where we have $   $$    $ construction
+                if inEnv and inEnv[-1] is not None and type(inEnv[-1]) is type(current):
+                    tex.pushToken(t)
+                else:
+                    current = self.ownerDocument.createElement('displaymath')
             else:
                 tex.pushToken(t)
             break

--- a/unittests/Primitives.py
+++ b/unittests/Primitives.py
@@ -1,3 +1,4 @@
+from plasTeX.TeX import TeX
 from helpers.utils import compare_output
 
 def test_expandafter():
@@ -17,3 +18,35 @@ def test_expandafter_once():
 
 def test_expandafter_non_macro():
     compare_output(r'\def\foo#1{#1.}\expandafter\foo ab')
+
+def test_evil_double_dollars():
+    tex = TeX()
+    tex.input('$a$$b$')
+    nodes = tex.parse().getElementsByTagName('math')
+    assert len(nodes) == 2
+    assert nodes[0].textContent == 'a'
+    assert nodes[1].textContent == 'b'
+
+def test_more_evil_double_dollars():
+    tex = TeX()
+    tex.input('$a$$$b$$$c$')
+    doc = tex.parse()
+    mathnodes = doc.getElementsByTagName('math')
+    assert len(mathnodes) == 2
+    assert mathnodes[0].textContent == 'a'
+    assert mathnodes[1].textContent == 'c'
+    displaymathnodes = doc.getElementsByTagName('displaymath')
+    assert len(displaymathnodes) == 1
+    assert displaymathnodes[0].textContent == 'b'
+
+def test_even_more_evil_double_dollars():
+    tex = TeX()
+    tex.input('$a$$$$$$$b$$')
+    doc = tex.parse()
+    mathnodes = doc.getElementsByTagName('math')
+    assert len(mathnodes) == 1
+    assert mathnodes[0].textContent == 'a'
+    displaymathnodes = doc.getElementsByTagName('displaymath')
+    assert len(displaymathnodes) == 2
+    assert displaymathnodes[0].textContent == ''
+    assert displaymathnodes[1].textContent == 'b'


### PR DESCRIPTION
Previously, the `$math$$math$`-type construction (with two dollar signs in a sequence without spaces) was treated incorrectly, because it was rendered as if it was a beginning of `displaymath` context inside. It led to a serious problem, because the whole document was within incorrect context after that moment.