### PR TITLE
Master

### DIFF
--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -153,7 +153,7 @@ class TeX(object):
         if self.jobname is None:
             if isinstance(source, str):
                 self.jobname = ''
-            elif isinstance(source, IOBase):
+            elif isinstance(source, IOBase) and hasattr(source,'name'):
                 self.jobname = os.path.basename(os.path.splitext(source.name)[0])
 
         t = Tokenizer(source, self.ownerDocument.context)

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -1321,7 +1321,7 @@ class TeX(object):
 
         return dictarg
 
-    def kpsewhich(self, name):
+    def kpsewhich(self, name, shortcircuit=True):
         """
         Locate the given file using kpsewhich
 
@@ -1340,6 +1340,12 @@ class TeX(object):
         
         srcDir = None if self.main_input_file is None else  os.path.dirname(self.main_input_file)
 
+        if shortcircuit and srcDir is not None:
+            n = name if os.path.isabs(name) else os.path.join(srcDir,name)
+            for j in (n, n+'.tex', n+'.sty'):
+                if os.path.isfile(j):
+                    return j
+            
         if srcDir is not None:
             TEXINPUTS = os.environ.get("TEXINPUTS",'')
             os.environ["TEXINPUTS"] = "%s%s%s%s" % (srcDir, os.path.pathsep, TEXINPUTS, os.path.pathsep)

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -122,6 +122,9 @@ class TeX(object):
                 or encoding is utf-8, make encoding utf_8_sig.
                 otherwise, use the specified encoding.
                 '''
+
+                self.main_input_file = file
+                
                 try:
                     encoding = self.ownerDocument.config['files'].get('input-encoding', 'utf_8_sig')
                 except (KeyError, AttributeError):
@@ -137,7 +140,10 @@ class TeX(object):
             # File object
             else:
                 self.input(file)
+                self.main_input_file = file.name
                 self.jobname = os.path.basename(os.path.splitext(file.name)[0])
+        else:
+            self.main_input_file = None
 
     def input(self, source):
         """
@@ -155,6 +161,9 @@ class TeX(object):
                 self.jobname = ''
             elif isinstance(source, IOBase) and hasattr(source,'name'):
                 self.jobname = os.path.basename(os.path.splitext(source.name)[0])
+
+        if self.main_input_file is None and isinstance(source, IOBase) and hasattr(source,'name'):
+            self.main_input_file = source.name
 
         t = Tokenizer(source, self.ownerDocument.context)
         self.inputs.append((t, iter(t)))

--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -1335,13 +1335,12 @@ class TeX(object):
         # When, for example, ``\Input{name}`` is encountered, we should look in
         # the directory containing the file being processed. So the following
         # code adds the directory to the start of $TEXINPUTS.
-        TEXINPUTS = None
-        try:
-            srcDir = os.path.dirname(self.filename)
-        except AttributeError:
-            # I think this happens only for the command line file.
-            pass
-        else:
+        #
+        TEXINPUTS = srcDir = None
+        
+        srcDir = None if self.main_input_file is None else  os.path.dirname(self.main_input_file)
+
+        if srcDir is not None:
             TEXINPUTS = os.environ.get("TEXINPUTS",'')
             os.environ["TEXINPUTS"] = "%s%s%s%s" % (srcDir, os.path.pathsep, TEXINPUTS, os.path.pathsep)
 

--- a/plasTeX/Tokenizer.py
+++ b/plasTeX/Tokenizer.py
@@ -205,6 +205,8 @@ class Tokenizer(object):
         if isinstance(source, str):
             source = StringIO(source)
             self.filename = '<string>'
+        elif isinstance(source, StringIO):
+            self.filename = '<string>'
         elif isinstance(source, bytes):
             source = TextIOWrapper(BytesIO(source), encoding='utf-8')
             self.filename = '<string>'


### PR DESCRIPTION
dear Patrick,

I noted an error in TeX.kpsewhich() .

The usual `kpsewhich` searches first and foremost  files  in the local directory ; where `local directory` means the directory of invocation.

`plastex` instead searches in the directory of the last input.

 The error is best explained by this example [ciao.zip](https://github.com/plastex/plastex/files/8111580/ciao.zip) where you can compare the outout of `pdflatex` , of plastex, and of plastex with my patches.

With my patch the output is the same.

Note that there is still a difference: with these patches, `plastex` is not behaving exactly as `pdflatex` . Indeed now `plastex` considers as `local directory` the directory where the main file is, and not the directory of invokation. But this (IMHO) is more sensible since `plastex` may be used as a library ( I do use it that way, inside a wsgi in apache) so the `cwd` is not really meaningful there. 

Explanation of patches.

- [TeX.input accepts StringIO](https://github.com/plastex/plastex/commit/35ddcef22a60caa6cd9b69c835464de11508739c)
 you can pass a StringIO to TeX.input and it will not crash

- [TeX record main input file](https://github.com/plastex/plastex/commit/4e4ab5d6010a36c6b56534dbfb1ff2533f75aade)
  save the name of the first input file 

- [kspewhich: local searches are wrt the main input filename](https://github.com/plastex/plastex/commit/5247a1ab39b3899d950b9fdc93988f4955f45ef3)
 use the directory of that file as a base for searches

- [kpsewhich faster for local files](https://github.com/plastex/plastex/commit/13c4eb08374289e5c8d6c4a0b79339b15b697c54)
  this is not related to the problem , it is an optimization: since the local directory is always
  searched first, then the python code gives a look, and avoids subprocess-ing kpsewhich
 if it finds the file.

This reduces the compilation time of the file in [ my website](https://coldoc.sns.it) to half. Note that my file is indeed  divided in many short fragments : this is one of the purposes of my [ColDoc project](https://github.com/mennucc/ColDoc_project)

  
