### PR TITLE
remove extra argument self in TextRenderer.do_footnotetext

### DIFF
--- a/plasTeX/Renderers/Text/__init__.py
+++ b/plasTeX/Renderers/Text/__init__.py
@@ -298,7 +298,7 @@ class TextRenderer(BaseRenderer):
         return mark
 
     def do_footnotetext(self, node):
-        self.do_footnote(self, node)
+        self.do_footnote(node)
         return ''
 
     def do_footnotemark(self, node):


### PR DESCRIPTION
self is already on the left.