### PR TITLE
Fix subsitution logic

### DIFF
--- a/plasTeX/Renderers/Text/__init__.py
+++ b/plasTeX/Renderers/Text/__init__.py
@@ -77,7 +77,7 @@ class TextRenderer(BaseRenderer):
             block = self.blocks[int(m.group(2))]
             block = space + block.replace('\n', u'\n%s' % space)
 
-            s = block_re.sub('%s%s' % (before, block), s, 1)
+            s = s[:m.start()] + before + block + s[m.end():]
 
         # Clean up newlines
         return re.sub(r'\s*\n\s*\n(\s*\n)+', r'\n\n\n', s)


### PR DESCRIPTION
The replacement pattern is compiled to resolve backreferences, and this may fail if there are backslashes etc. included.
A simple string operation supposedly does what was intended?

```
    s = block_re.sub('%s%s' % (before, block), s, 1)
  File "/usr/lib/python3.9/re.py", line 327, in _subx
    template = _compile_repl(template, pattern)
  File "/usr/lib/python3.9/re.py", line 318, in _compile_repl
    return sre_parse.parse_template(repl, pattern)
  File "/usr/lib/python3.9/sre_parse.py", line 1042, in parse_template
    raise s.error('bad escape %s' % this, len(this))
re.error: bad escape \m at position 52 (line 3, column 51)
```