### PR TITLE
bug fix for #274 line numbering inconsistency

### DIFF
--- a/plasTeX/Tokenizer.py
+++ b/plasTeX/Tokenizer.py
@@ -302,6 +302,8 @@ class Tokenizer(object):
 
         """
         self._charBuffer.insert(0, char)
+        if char == '\n':
+            self.lineNumber -= 1
 
     def pushToken(self, token):
         """


### PR DESCRIPTION
When pushing back a newline to be parsed again, decrement the line count. Otherwise the lines get double counted, and reported line numbers are wrong.

Closes #274, MWE there