### PR TITLE
Fix overescaped backslash in tabbing

### DIFF
--- a/plasTeX/Base/LaTeX/Tabbing.py
+++ b/plasTeX/Base/LaTeX/Tabbing.py
@@ -16,7 +16,7 @@ class tabbing(Environment):
         macroName = '>'
 
     class EndRow(Command):
-        macroName = '\\\\'
+        macroName = '\\'
    
     class kill(Command):
         pass


### PR DESCRIPTION
An additional `\` is automatically prefixed, c.f., `EndRow` in other contexts.