### PR TITLE
split level is ignored if template does not contain a space?

### DIFF
--- a/plasTeX/Renderers/__init__.py
+++ b/plasTeX/Renderers/__init__.py
@@ -406,7 +406,7 @@ class Renderer(dict):
 
         self.level = config["files"]["split-level"]
         filenameTemplate = config["files"]["filename"].strip()
-        if ' ' not in filenameTemplate and '[' not in filenameTemplate:
+        if not '$' in filenameTemplate:
             self.level = -10
 
         # If there are no keys, print a warning.


### PR DESCRIPTION
This works with the default template `index [$id,sect$num(4)]` *but* it will disable splitting for the template `sect$num(4)`? IMHO, the dollar is more indicative of a template that can generate suitable file names?