### PR TITLE
Beamer: columns may have overlays

### DIFF
--- a/plasTeX/Packages/beamer.py
+++ b/plasTeX/Packages/beamer.py
@@ -288,10 +288,10 @@ class beamerboxesrounded(Environment):
     args = '[ options:dict ] title'
 
 class columns(Environment):
-    args = '[ options:dict ]'
+    args = '< overlay > [ options:dict ]'
 
 class column(Command):
-    args = '[ placement ] width'
+    args = '< overlay > [ placement ] width'
     def invoke(self, tex):
         # This macro can be an environment or a command each 
         # with different arguments.


### PR DESCRIPTION
This was the cause for `\linewidth` to become zero in my documents.
```tex
\begin{columns}<1>[totalwidth=\linewidth]
```
It is not very common, but I used something like `<1|handout:0>` to hide the columns in the handout. This caused the remainder to be parsed as commands, i.e., `\linewidth` with missing number as `\linewidth=0pt`. I think it *should* do this only if followed by an equals sign?

But even if that is not the root cause, these two commands are missing the overlay parameter.
```
beamerbaseframecomponents.sty:\newenvironment<>{columns}[1][]{%
beamerbaseframecomponents.sty:\newenvironment<>{beamer@columnenv}[2][\beamer@colmode]{%
```