### PR TITLE
Avoid unnecessary list copies/reversal

### DIFF
--- a/plasTeX/Tokenizer.py
+++ b/plasTeX/Tokenizer.py
@@ -325,9 +325,7 @@ class Tokenizer(object):
 
         """
         if tokens:
-            tokens = list(tokens)
-            tokens.reverse()
-            for t in tokens:
+            for t in tokens[::-1]:
                 self.pushToken(t)
 
     def __iter__(self):

--- a/plasTeX/__init__.py
+++ b/plasTeX/__init__.py
@@ -314,10 +314,8 @@ class Macro(Element):
             return vars(tself)[localsname]
         except KeyError:
             pass
-        mro = list(tself.__mro__)
-        mro.reverse()
         loc = {}
-        for cls in mro:
+        for cls in tself.__mro__[::1]:
             for value in list(vars(cls).values()):
                 if ismacro(value):
                     loc[macroName(value)] = value
@@ -1124,7 +1122,7 @@ def expandDef(definition, params):
     return output
 
 class NewCommand(Macro):
-    """ Superclass for all \newcommand/\newenvironment type commands """
+    r""" Superclass for all \newcommand/\newenvironment type commands """
     nargs = 0
     opt = None
     definition = None
@@ -1160,7 +1158,7 @@ class NewCommand(Macro):
         return output + expandDef(self.definition, params)
 
 class Definition(Macro):
-    """ Superclass for all \\def-type commands """
+    r""" Superclass for all \def-type commands """
     args = '' # type: str
     definition = None # type: Optional[str]
 
@@ -1630,7 +1628,7 @@ class Counter(object):
 
 
 class TheCounter(Command):
-    """ Base class for \\thecounter commands """
+    r""" Base class for \thecounter commands """
     format = None
     trimLeft = False
 


### PR DESCRIPTION
Also, adjust docstring escaping (NewMacro docstring was incorrect), prefer raw strings.