### PR TITLE
Fix parsing of smallmatrix

### DIFF
--- a/plasTeX/Packages/amsmath.py
+++ b/plasTeX/Packages/amsmath.py
@@ -94,8 +94,7 @@ class bmatrix(Array):
 class Bmatrix(Array):
     pass
 
-#### Inline Math
-class smallmatrix(MathEnvironmentPre):
+class smallmatrix(Array):
     pass
 
 class dddot(math):


### PR DESCRIPTION
It needs to be parsed as array.

MWE:
```tex
\documentclass{article}
\usepackage{amsmath}
\begin{document}
\begin{align*}
\begin{smallmatrix} 1 & 2 \end{smallmatrix}
\end{align*}
\end{document}
```
is otherwise parsed as 
```xml
<dom-document xmlns:plastex="http://plastex.sf.net/">
<documentclass id="a0000000001">
    <plastex:arg name="options"/>
    <plastex:arg name="name">article</plastex:arg>
</documentclass> <usepackage id="a0000000002">
    <plastex:arg name="options"/>
    <plastex:arg name="names">['amsmath']</plastex:arg>
</usepackage> <document id="a0000000003">
 <align modifier="*" id="a0000000004">
<ArrayRow id="a0000000005">
<ArrayCell id="a0000000006">
<par id="a0000000007">
 <smallmatrix id="a0000000008">
 1 </smallmatrix></par></ArrayCell><ArrayCell id="a0000000009">
<par id="a0000000010">
 2 </par></ArrayCell></ArrayRow></align></smallmatrix> </align modifier="*"> </document> <par id="a0000000013"/></dom-document>
```
Note the double closing of `/smallmatrix`