### PR TITLE
rudimentary support for \begin{enumerate}[start=4] (enumitem package)

### DIFF
--- a/plasTeX/Packages/enumitem.py
+++ b/plasTeX/Packages/enumitem.py
@@ -1,0 +1,14 @@
+from plasTeX.Base.LaTeX.Lists import List
+class enumerate_(List):
+    macroName = 'enumerate'
+    args = '[ options:dict ]'
+    def invoke(self, tex):
+        List.invoke(self,tex)
+        options = self.attributes.get('options',{})
+        self.start = options.get('start', 0)
+        if self.start != 0:
+            self.ownerDocument.context.counters[List.counters[List.depth]].setcounter(int(self.start))
+        # TODO: handle more keywords and warn for those which are ignored (many)
+        # TODO (?): shortlabels package option, when first non-keyword
+        #           (appears as ... = True in options:dict) is enumerate-package-style label style
+

--- a/plasTeX/Renderers/HTML5/Lists.jinja2s
+++ b/plasTeX/Renderers/HTML5/Lists.jinja2s
@@ -6,7 +6,11 @@ name: itemize
 </ul>
 
 name: enumerate
+{% if obj.start==0 %}
 <ol class="enumerate">
+{% else %}
+<ol class="enumerate" start="{{ obj.start }}">
+{% endif %}
 {% for item in obj %}
   <li>{{ item }}</li>
 {% endfor %}

--- a/plasTeX/Renderers/HTML5/Lists.jinja2s
+++ b/plasTeX/Renderers/HTML5/Lists.jinja2s
@@ -6,10 +6,10 @@ name: itemize
 </ul>
 
 name: enumerate
-{% if obj.start==0 %}
-<ol class="enumerate">
-{% else %}
+{% if obj.start is defined %}
 <ol class="enumerate" start="{{ obj.start }}">
+{% else %}
+<ol class="enumerate">
 {% endif %}
 {% for item in obj %}
   <li>{{ item }}</li>


### PR DESCRIPTION
Please check this out, a sample document would be 
```tex
\documentclass{article}
\usepackage{enumitem}
\begin{document}
	\begin{enumerate}[start=4]
		\item foo 
		\item bar
	\end{enumerate}
\end{document}
```

which renders (HTML5 only) correctly as 

> 4. foo
> 5. bar

If you give it a green light, I would add unit tests, and support for some more enumitem options.