### PR TITLE
Normalise root directory in texinputs

### DIFF
--- a/plasTeX/Imagers/__init__.py
+++ b/plasTeX/Imagers/__init__.py
@@ -603,7 +603,7 @@ width 2pt\hskip2pt}}{}
         for folder in os.environ.get('TEXINPUTS', '').split(os.pathsep):
             if folder.strip():
                 folders.append(str((root/folder).absolute()))
-        new_texinputs = os.pathsep.join(['.'] + folders) + os.pathsep
+        new_texinputs = os.pathsep.join([str(root.absolute())] + folders) + os.pathsep
 
         # Make a temporary directory to work in. We don't use
         # `with TemporaryDirectory() as tempdir` because we want to retain the


### PR DESCRIPTION
The blueprint at leanprover-community/liquid stopped building after ac0369937d8e011c8191484b26a1825f45481bdc, see logs [before](https://github.com/collares/liquid/actions/runs/5561140520/jobs/10158610045) and [after](https://github.com/collares/liquid/actions/runs/5561141722/jobs/10158612139) this commit. This PR [fixes the liquid blueprint](https://github.com/collares/liquid/actions/runs/5561221846/jobs/10158754911), but I am not familiar enough with the code to be sure the change is sound.