### PR TITLE
Fix image comparison process call

### DIFF
--- a/unittests/helpers/utils.py
+++ b/unittests/helpers/utils.py
@@ -10,7 +10,7 @@ CACHE_LOCATION = Path(__file__).absolute().parent / "compare_cache"
 
 def cmp_img(a: str, b: str) -> float:
     out = subprocess.run(["compare", "-quiet", "-metric", "MSE",
-        '-subimage-search', a, b, "/dev/null"],
+        '-subimage-search', a, b, "NULL:"],
         stderr=subprocess.PIPE, stdin=subprocess.DEVNULL, check=False)
 
     # return code 1 is for dissimilar images, but we use our own threshold
@@ -20,7 +20,7 @@ def cmp_img(a: str, b: str) -> float:
             def __init__(self, message):
                 self.message = message
         out = subprocess.run(["compare", "-verbose", "-metric", "MSE",
-            '-subimage-search', a, b, "/dev/null"],
+            '-subimage-search', a, b, "NULL:"],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.DEVNULL,
             check=False)
         print(out.stdout.decode())


### PR DESCRIPTION
Imagemagick's `compare` program accepts three image arguments: `input1`,` input2`, `output`. As is standard within imagemagick, there are magic filenames that change behaviour; if the output image is not wanted then `NULL:` is the correct filename to use. The existing code uses `/dev/null` which is not portable across operating systems, and in some circumstances imagemagick will attempt to generate output files of `/dev/null-0` and `/dev/null-1`, which then fails. This may already be an issue on CI that is papered over by CI running with elevated privileges within the container.

https://imagemagick.org/Usage/compare/