### PR TITLE
Fix image cache

### DIFF
--- a/plasTeX/Imagers/__init__.py
+++ b/plasTeX/Imagers/__init__.py
@@ -468,7 +468,7 @@ class Imager(object):
                                           self.__class__.__name__+'.images'))
         if self.config['images']['cache'] and os.path.isfile(self._filecache):
             try:
-                self._cache = pickle.load(open(self._filecache, 'r'))
+                self._cache = pickle.load(open(self._filecache, 'rb'))
                 for key, value in list(self._cache.items()):
                     if not os.path.isfile(value.filename):
                         del self._cache[key]


### PR DESCRIPTION
Written as binary, read as system encoding. use "rb" and "wb" consistently.

https://github.com/plastex/plastex/blob/408b07a1f8cdf47df76056141498d704510add6a/plasTeX/Imagers/__init__.py#L683