### PR TITLE
HTML5: renderer: Changes 'equation' content to mathjax_source

### DIFF
--- a/plasTeX/Renderers/HTML5/Math.jinja2s
+++ b/plasTeX/Renderers/HTML5/Math.jinja2s
@@ -13,7 +13,7 @@ name: equation
 <div class="equation" id="{{ obj.id }}">
 <p>
   <div class="equation_content">
-    {{ obj.source }}
+    {{ obj.mathjax_source }}
   </div>
   <span class="equation_label">{{ obj.ref }}</span>
 </p>


### PR DESCRIPTION
In HTML5 renderer, 'equation' environment: Changed: 'obj.source' to 'obj.mathjax_source'.

I ran into an issue related to this when using inequalities ('<' or '>') in equation environments. It seems that using 'obj.source', these do not get escaped, and lead to problems. This patch switches 'obj.source' to 'obj.mathjax_source', and thus makes plastex escape '<' and '>' in 'equation' environments.