### PR TITLE
Missing double escape

### DIFF
--- a/plasTeX/Packages/xy.py
+++ b/plasTeX/Packages/xy.py
@@ -29,7 +29,7 @@ class xymatrix(Command):
     class omit(Command):
         @property
         def source(self):
-            return '\omit'
+            return '\\omit'
 
     def preArgument(self, arg, tex):
             # Check whether there are any spacing arguments for xymatrix


### PR DESCRIPTION
```
/usr/lib/python3/dist-packages/plasTeX/Packages/xy.py:32: SyntaxWarning: invalid escape sequence '\o'
  return '\omit'
```