### PR TITLE
amsthm: change \newtheorem to take any TeXFragment as a header

### DIFF
--- a/plasTeX/Packages/amsthm.py
+++ b/plasTeX/Packages/amsthm.py
@@ -159,13 +159,13 @@ class newtheoremstyle(Command):
 
 
 class newtheorem(Command):
-    args = '* name:str [ shared:str ] header:str [ parent:str]'
+    args = '* name:str [ shared:str ] header [ parent:str]'
 
     def invoke(self, tex):
         self.parse(tex)
         a = self.attributes
         name = str(a['name'])
-        header = a['header']
+        header = a['header'].textContent
         star = a['*modifier*'] == '*'
         parent = a['parent']
         shared = a['shared']

--- a/unittests/amsthm/benchmark.html
+++ b/unittests/amsthm/benchmark.html
@@ -148,6 +148,18 @@
 
   </div>
 </div>
+<div class="extrabracketed_thmwrapper theorem-style-plain" id="a0000000013">
+  <div class="extrabracketed_thmheading">
+    <span class="extrabracketed_thmcaption">
+    Extra bracketed
+    </span>
+    <span class="extrabracketed_thmlabel">1</span>
+  </div>
+  <div class="extrabracketed_thmcontent">
+  <p>A theorem whose header argument has an extra pair of curly braces. </p>
+
+  </div>
+</div>
 
 </div> <!--main-text -->
 </div> <!-- content-wrapper -->

--- a/unittests/amsthm/source.tex
+++ b/unittests/amsthm/source.tex
@@ -18,6 +18,8 @@
 \newtheorem{within}{Within}[section]
 \newtheorem{withinshared}[within]{Within And Shared}
 
+\newtheorem{extrabracketed}{{Extra bracketed}}
+
 \begin{document}
 
 \section{A section}
@@ -52,4 +54,8 @@
 \begin{withinshared}\label{T:1}
     A theorem with counter shared with a theorem numbered within sections
 \end{withinshared}
+
+\begin{extrabracketed}
+    A theorem whose header argument has an extra pair of curly braces.
+\end{extrabracketed}
 \end{document}


### PR DESCRIPTION
I encountered a LaTeX file where the header arguments to `\newtheorem` were wrapped in an extra pair of curly braces. pdflatex was fine with this, but plasTeX wasn't: it expected a plain string, so since the header argument was a `bgroup` element, it was lost.

This commit changes the type of the header argument to take any TeX fragment, and then takes its `textContent`.