### PR TITLE
tox tested minimal changes to support plastex issue 358

### DIFF
--- a/plasTeX/Config.py
+++ b/plasTeX/Config.py
@@ -64,6 +64,12 @@ def defaultConfig(loadConfigFiles: bool=False):
         default = [],
     )
 
+    general['add-plugins'] = BooleanOption(
+        """Add all installed PlasTeX plugins.""",
+        options = '--add-plugins',
+        default = False,
+    )
+
     general['plugins'] = MultiStringOption(
         """
         A list of plugins to use. Each element must be a valid python module name,

--- a/plasTeX/client.py
+++ b/plasTeX/client.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os, sys
-import traceback
 import importlib, pkgutil
 import traceback, pdb
 import plasTeX
@@ -26,7 +25,7 @@ def collect_plastex_renderer_plugins_config(config):
             try:
                 conf = importlib.import_module(name)
             except ImportError:
-                #print(traceback.format_exc(limit=-1))
+                #print(f"Loading Renderers Options from {name}: "+traceback.format_exc(limit=-1))
                 continue
 
             if hasattr(conf, 'addConfig') and callable(getattr(conf, 'addConfig')):


### PR DESCRIPTION
This PR adds the ability to discover and load any Python package previously installed which follows a (new) PlasTeX plugin naming policy: `plastex_XXXX_plugin`. 

This PR provides a potential solution to the PlasTeX issue plastex/plastex#358.

It makes a very small **change in the Config.py file**, to add a new `--add-plugins` option which currently defaults to False, hence providing almost current behaviour. 

It also makes rather more **changes to the client.py file**. These changes do two things:

1. **Before command line options are parsed:** Discover any python packages which start with `plastex_` and end with `_plugin`. *If* the found package contains the python file `Renderers/Config.py` which itself contains an `addConfig` method, *then* this `addConfig` method is run with the PlasTeX `config` structure as its only argument, hence allowing the PlasTeX plugin to add command line options.
  - This functionality is currently *not* provided by the existing "plugins" system, and is needed to help, for example, split the Gerby specific code into a plugin which can (eventually) work with the existing (and heavily updated) PlasTeX code base.
2. **After command line options have been parsed:** Implements the `--add-plugins` option (if found) by *adding* the names of all installed PlasTeX plugins to the end of the existing PlasTeX `--plugins` option (list of strings). Hence all of the existing plugins implementation is essentially unchanged.

These changes ensure that existing behaviour is kept (except for the addition of a plugin's Renderers Options to the PlasTeX command line arguments).

It leverages the existing `plugins` code as it current exists to load TeX styles and/or Renderers.

---

**Testing using existing PlasTeX tests:** 

This PR has been tested (as the `plastex_issue_358` branch) using Tox (as requested in [plastex CONTRIBUTING document](https://github.com/plastex/plastex/blob/master/CONTRIBUTING.md)) using the [diSimplex/plastex-tox](https://github.com/diSimplex/plastex-tox) tool. 

(This `plastex-tox` tool tests a version of PlasTeX inside a specified Podman (Dockerfile) instance with known installation, using `tox` as described by the [plastex/plastex/tox.ini](https://github.com/plastex/plastex/blob/master/tox.ini) file).  

In all cases (python 3.7-3.12) there were two failures in *both* the existing PlasTeX repo and the `plastex_issue_358` branch of this repo. (Python 3.6 can no longer be tested out of the box with the new Tox versions).

In all failures there seems to be a problem with the `tikz`/`lualatex` and `pdf2svg` provided commands in the `plastex-tox` Dockerfile description (which was modelled upon the most recent Github action tests for PlasTeX).

Since this PR has no interaction with either `tikz`/`lualatex` or `pdf2svg`, I conclude that there is a problem with the testing environment (any pointers to correct this would be welcome) as opposed to any problems introduced by this PR.