### PR TITLE
The enumerate environment ignores children which are not \item

### DIFF
--- a/plasTeX/Base/LaTeX/Lists.py
+++ b/plasTeX/Base/LaTeX/Lists.py
@@ -16,6 +16,7 @@ class List(Environment):
     depth = 0
     counters = ['enumi','enumii','enumiii','enumiv']
     blockType = True
+    allowedChildren = None # A list of names of nodes that can be direct children of this node.
 
     class item(Command):
         args = '[ term ]'
@@ -70,9 +71,8 @@ class List(Environment):
                 elif tok.nodeName == 'setcounter':
                     tok.digest([])
                     continue
-#               if tok.nodeName != 'item':
-#                   log.warning('dropping non-item from beginning of list')
-#                   continue
+                elif self.allowedChildren is not None and tok.nodeName not in self.allowedChildren:
+                    continue
                 tokens.push(tok)
                 break
         Environment.digest(self, tokens) 
@@ -98,6 +98,7 @@ class labelitemiv(Command):
 class enumerate_(List): 
     macroName = 'enumerate'
     args = '[ type ]'  # Actually defined in the enumerate package, but it doesn't hurt
+    allowedChildren = ('item',)
 
 class description(List): 
     pass


### PR DESCRIPTION
There was a very old case in the List environment's digest method which would ignore child nodes whose name is not 'item'. It looks like this was added so that unimplemented macros at the start of an `enumerate` environment don't produce list items in the output.

The List class is now used by quite a few other macros, which do allow other types of children. In particular, the bibliography unit tests failed when I tried just uncommenting the code.

This adds an `allowedChildren` attribute to List, which is `None` by default. When it's an iterable of node names, only nodes with those names are allowed, and all others are ignored. The `enumerate` class sets `allowedChildren = ('item',)`.