### PR TITLE
add a dummy amsbsy package

### DIFF
--- a/plasTeX/Packages/amsbsy.py
+++ b/plasTeX/Packages/amsbsy.py
@@ -1,0 +1,9 @@
+from plasTeX import Command
+
+# Dummy amsbsy package - handled by mathjax
+
+class pmb(Command):
+    pass
+
+class boldsymbol(Command):
+    pass

--- a/unittests/Packages/amsbsy.py
+++ b/unittests/Packages/amsbsy.py
@@ -1,0 +1,16 @@
+import pytest
+from plasTeX.TeX import TeX
+
+def test_amsbsy():
+    tex = TeX()
+    tex.input(r'''
+\documentclass{article}
+\usepackage{amsbsy}
+\begin{document}
+$\boldsymbol{\infty}$
+\end{document}''')
+
+    doc = tex.parse()
+
+    # SImply test that parsing caused no error
+    assert len(doc.getElementsByTagName('boldsymbol')) == 1


### PR DESCRIPTION
The amsbsy package provides math-mode commands \pmb and \boldsymbol. In HTML, MathJax implements these commands.

This dummy package prevents plasTeX from trying to load the real LaTeX amsbsy package.