### PR TITLE
add the cancel package

### DIFF
--- a/plasTeX/Packages/cancel.py
+++ b/plasTeX/Packages/cancel.py
@@ -1,0 +1,14 @@
+from plasTeX import Command
+
+
+class cancel(Command):
+    args = 'self'
+
+class bcancel(Command):
+    args = 'self'
+
+class xcancel(Command):
+    args = 'self'
+
+class cancelto(Command):
+    args = 'to content'

--- a/unittests/Packages/cancel.py
+++ b/unittests/Packages/cancel.py
@@ -1,0 +1,13 @@
+from plasTeX.TeX import TeX
+
+def test_cancel():
+    t = TeX()
+    t.input(r'''
+\documentclass{article}
+\usepackage{cancel}
+\begin{document}
+\( \cancel{x} \xcancel{x} \bcancel{x} \cancelto{y}{x} \)
+\end{document}
+''')
+    p = t.parse()
+    assert p.getElementsByTagName('math')[0].source == r'$ \cancel{x} \xcancel{x} \bcancel{x} \cancelto{y}{x} $'


### PR DESCRIPTION
MathJax implements the cancel commands, so plasTeX just needs to pass them through, and not load the LaTeX version.