### PR TITLE
implement the package doublestroke/dsfont

### DIFF
--- a/plasTeX/Packages/dsfont.py
+++ b/plasTeX/Packages/dsfont.py
@@ -1,0 +1,9 @@
+from plasTeX import Command, sourceArguments
+
+
+class mathds(Command):
+    args = 'self'
+
+    @property
+    def source(self):
+        return r'\mathbb{obj}'.format(obj=sourceArguments(self).strip())

--- a/unittests/Packages/dsfont.py
+++ b/unittests/Packages/dsfont.py
@@ -1,0 +1,14 @@
+from plasTeX.TeX import TeX
+
+def test_dsfont():
+    t = TeX()
+    t.input(r'''
+\documentclass{article}
+\usepackage{dsfont}
+\begin{document}
+$ \mathds{x} $
+\end{document}
+''')
+    p = t.parse()
+
+    assert p.getElementsByTagName('math')[0].source == r'$ \mathbb{x} $'


### PR DESCRIPTION
The LaTeX package [doublestroke](https://ctan.org/tex-archive/fonts/doublestroke) (imported as dsfont) supplies a font of double-struck characters.

This implements the package in plasTeX by rewriting \mathds{.} to \mathbb{.}, so MathJax will use doublestruck characters from its fonts.