### PR TITLE
Fix mathjax-macros

### DIFF
--- a/plasTeX/Renderers/HTML5/Themes/default/default-layout.jinja2
+++ b/plasTeX/Renderers/HTML5/Themes/default/default-layout.jinja2
@@ -21,9 +21,9 @@
   MathJax = { 
     tex: {
 {% if config.html5['mathjax-dollars'] %}
-		    inlineMath: [['$','$'], ['\\(','\\)']]
+		    inlineMath: [['$','$'], ['\\(','\\)']],
 {% else %}
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 {% endif %}
 {% if config['mathjax-macros']['macros'] %}
       macros: { {% for key, val in config['mathjax-macros']['macros'].items() %}

--- a/plasTeX/Renderers/HTML5/Themes/default/document-layout.jinja2
+++ b/plasTeX/Renderers/HTML5/Themes/default/document-layout.jinja2
@@ -21,9 +21,9 @@
   MathJax = { 
     tex: {
 {% if config.html5['mathjax-dollars'] %}
-		    inlineMath: [['$','$'], ['\\(','\\)']]
+		    inlineMath: [['$','$'], ['\\(','\\)']],
 {% else %}
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 {% endif %}
 {% if config['mathjax-macros']['macros'] %}
       macros: { {% for key, val in config['mathjax-macros']['macros'].items() %}

--- a/plasTeX/Renderers/HTML5/Themes/minimal/default-layout.jinja2
+++ b/plasTeX/Renderers/HTML5/Themes/minimal/default-layout.jinja2
@@ -6,9 +6,9 @@
   MathJax = { 
     tex: {
 {% if config.html5['mathjax-dollars'] %}
-		    inlineMath: [['$','$'], ['\\(','\\)']]
+		    inlineMath: [['$','$'], ['\\(','\\)']],
 {% else %}
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 {% endif %}
 {% if config['mathjax-macros']['macros'] %}
       macros: { {% for key, val in config['mathjax-macros']['macros'].items() %}

--- a/unittests/Packages/benchmarks/babel.html
+++ b/unittests/Packages/benchmarks/babel.html
@@ -4,7 +4,7 @@
 <script>
   MathJax = { 
     tex: {
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 	} }
 </script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">

--- a/unittests/Packages/benchmarks/bib.html
+++ b/unittests/Packages/benchmarks/bib.html
@@ -4,7 +4,7 @@
 <script>
   MathJax = { 
     tex: {
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 	} }
 </script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">

--- a/unittests/Packages/benchmarks/multibib.html
+++ b/unittests/Packages/benchmarks/multibib.html
@@ -4,7 +4,7 @@
 <script>
   MathJax = { 
     tex: {
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 	} }
 </script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">

--- a/unittests/Packages/benchmarks/natbib.html
+++ b/unittests/Packages/benchmarks/natbib.html
@@ -4,7 +4,7 @@
 <script>
   MathJax = { 
     tex: {
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 	} }
 </script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">

--- a/unittests/Packages/benchmarks/textcomp.html
+++ b/unittests/Packages/benchmarks/textcomp.html
@@ -4,7 +4,7 @@
 <script>
   MathJax = { 
     tex: {
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 	} }
 </script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">

--- a/unittests/amsthm/benchmark.html
+++ b/unittests/amsthm/benchmark.html
@@ -4,7 +4,7 @@
 <script>
   MathJax = { 
     tex: {
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 	} }
 </script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">

--- a/unittests/benchmarks/Alignment.html
+++ b/unittests/benchmarks/Alignment.html
@@ -4,7 +4,7 @@
 <script>
   MathJax = { 
     tex: {
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 	} }
 </script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">

--- a/unittests/benchmarks/align.html
+++ b/unittests/benchmarks/align.html
@@ -4,7 +4,7 @@
 <script>
   MathJax = { 
     tex: {
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 	} }
 </script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">

--- a/unittests/benchmarks/footnotes.html
+++ b/unittests/benchmarks/footnotes.html
@@ -4,7 +4,7 @@
 <script>
   MathJax = { 
     tex: {
-		    inlineMath: [['\\(','\\)']]
+		    inlineMath: [['\\(','\\)']],
 	} }
 </script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">


### PR DESCRIPTION
This was always a javascript syntax error due to a missing comma between dictionary entries.
Trailing commas are fine.