### PR TITLE
add blank amsopn package

### DIFF
--- a/plasTeX/Packages/amsopn.py
+++ b/plasTeX/Packages/amsopn.py
@@ -1,0 +1,1 @@
+from .amsmath import DeclareMathOperator


### PR DESCRIPTION
It's part of amsmath; if someone tries to use it directly this will prevent plasTeX from trying to load the original LaTeX version.