### PR TITLE
Enable testing with Python 3.13

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
+          cache: pip
+          cache-dependency-path: requirements*.txt
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install --no-install-recommends dvisvgm dvipng imagemagick inkscape pdf2svg poppler-utils texlive-binaries texlive-latex-base texlive-latex-extra texlive-extra-utils texlive-xetex

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v2
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install --no-install-recommends dvisvgm dvipng imagemagick inkscape pdf2svg poppler-utils texlive-binaries texlive-latex-base texlive-latex-extra texlive-extra-utils texlive-xetex

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/plasTeX/Renderers/PageTemplate/simpletal/simpleTALUtils.py
+++ b/plasTeX/Renderers/PageTemplate/simpletal/simpleTALUtils.py
@@ -34,7 +34,7 @@
 		Module Dependencies: None
 """
 
-import io, os, stat, threading, codecs, cgi, re
+import io, os, stat, threading, codecs, html, re
 from . import __version__, simpleTAL
 
 # This is used to check for already escaped attributes.
@@ -114,7 +114,7 @@ def tagAsText (tag,atts):
 			# We already have some escaped characters in here, so assume it's all valid
 			result += ' %s="%s"' % (name, value)
 		else:
-			result += ' %s="%s"' % (name, cgi.escape (value))
+			result += ' %s="%s"' % (name, html.escape (value))
 	result += ">"
 	return result
 
@@ -195,11 +195,11 @@ class MacroExpansionInterpreter (simpleTAL.TemplateInterpreter):
 						self.file.write (str (str (resultVal), 'ascii'))
 			else:
 				if (isinstance (resultVal, str)):
-					self.file.write (cgi.escape (resultVal))
+					self.file.write (html.escape (resultVal))
 				elif (isinstance (resultVal, bytes)):
-					self.file.write (cgi.escape (str (resultVal, 'ascii')))
+					self.file.write (html.escape (str (resultVal, 'ascii')))
 				else:
-					self.file.write (cgi.escape (str (str (resultVal), 'ascii')))
+					self.file.write (html.escape (str (str (resultVal), 'ascii')))
 
 		if (self.outputTag and not args[1]):
 			self.file.write ('</' + args[0] + '>')


### PR DESCRIPTION
This PR

- enables testing with Python 3.13 (rc)
- updates the versions of the actions to reduce noise from CI
- lets the python action cache pip downloads more aggressively
- fixes compatibility with Python 3.13

The original purpose of this work was to address the removal of the `cgi` module in Python 3.13 - that fix is in the final commit, where `html.escape` replaces `cgi.escape`. However... while the `cgi` module only gets removed in Python 3.13, the actual `cgi.escape` function was removed in Python 3.8. 

There's not much test coverage of `simpletal` for this to have gone unnoticed for so long (see below). Presumably there are also no users of `simpletal` given no-one has complained in 5 years. This PR is safe to merge as is, but perhaps it's appropriate to just remove `simpletal` in a future release.

Test coverage:
```
plasTeX/Renderers/PageTemplate/simpletal/FixedHTMLParser.py                                                                                4      1    75%
plasTeX/Renderers/PageTemplate/simpletal/__init__.py                                                                                       1      0   100%
plasTeX/Renderers/PageTemplate/simpletal/sgmlentitynames.py                                                                                1      0   100%
plasTeX/Renderers/PageTemplate/simpletal/simpleTAL.py                                                                                    941    800    15%
plasTeX/Renderers/PageTemplate/simpletal/simpleTALES.py                                                                                  436    367    16%
plasTeX/Renderers/PageTemplate/simpletal/simpleTALUtils.py                                                                               128    128     0%
```