### PR TITLE
Fix bugs in kpsewhich

### DIFF
--- a/plasTeX/TeX.py
+++ b/plasTeX/TeX.py
@@ -1357,16 +1357,16 @@ class TeX(object):
 
             try:
                 program = self.ownerDocument.config['general']['kpsewhich']
-    
+
                 kwargs = {'stdout':subprocess.PIPE}
                 if sys.platform.lower().startswith('win'):
                     kwargs['shell'] = True
-    
+
                 output = subprocess.Popen([program, name], **kwargs).communicate()[0].strip()
                 output = output.decode('utf-8')
                 if output:
                     return output
-    
+
             except Exception:
                 paths = os.environ.get("TEXINPUTS", '.').split(os.path.pathsep)
                 for path in paths:

--- a/unittests/Input.py
+++ b/unittests/Input.py
@@ -1,6 +1,29 @@
 from pathlib import Path
 from plasTeX.TeX import TeX
 from plasTeX import Command
+import contextlib
+import os
+import textwrap
+import pytest
+
+
+@contextlib.contextmanager
+def local_env_var(name, value):
+    try:
+        old = os.environ[name]
+    except KeyError:
+        os.environ[name] = value
+        try:
+            yield
+        finally:
+            del os.environ[name]
+    else:
+        os.environ[name] = value
+        try:
+            yield
+        finally:
+            os.environ[name] = old
+
 
 class foo(Command):
     def invoke(self, tex):
@@ -36,6 +59,46 @@ def test_input_without_kpsewhich(tmpdir):
         tex.ownerDocument.config['general']['kpsewhich'] = ''
 
         assert "./input2.tex" == tex.parse().getElementsByTagName("foo")[0].data
+
+
+@pytest.mark.parametrize('without_kpsewhich', [False, True])
+def test_input_nested_path(tmp_path, without_kpsewhich):
+    (tmp_path / "input.tex").write_text(textwrap.dedent(r'''
+        \documentclass{article}
+        \begin{document}
+        \input{nested/input2.tex}
+        \end{document}
+        '''))
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "nested" / "input2.tex").write_text(r'\foo')
+
+    # deliberately test the case where the working directory is elsewhere
+    with local_env_var("TEXINPUTS", str(tmp_path)):
+        tex = TeX(file="input.tex")
+        tex.ownerDocument.context.contexts[0]["foo"] = foo
+        if without_kpsewhich:
+            tex.ownerDocument.config['general']['kpsewhich'] = ''
+
+        assert str(tmp_path / "nested" / "input2.tex") == tex.parse().getElementsByTagName("foo")[0].data
+
+
+@pytest.mark.parametrize('without_kpsewhich', [False, True])
+def test_input_absolute_path(tmp_path, without_kpsewhich):
+    (tmp_path / "input.tex").write_text(textwrap.dedent(r'''
+        \documentclass{article}
+        \begin{document}
+        \input{''' + str(tmp_path / "input2.tex") + r'''}
+        \end{document}
+        '''))
+    (tmp_path / "input2.tex").write_text(r'\foo')
+
+    tex = TeX(file=str(tmp_path / "input.tex"))
+    tex.ownerDocument.context.contexts[0]["foo"] = foo
+    if without_kpsewhich:
+        tex.ownerDocument.config['general']['kpsewhich'] = ''
+
+    assert str(tmp_path / "input2.tex") == tex.parse().getElementsByTagName("foo")[0].data
+
 
 def test_input_without_kpsewhich_without_extension(tmpdir):
     with tmpdir.as_cwd():


### PR DESCRIPTION
When `kpsewhich` was not installed, this could:
* not resolve absolute paths.
* not resolve paths of the form `foo/bar.tex`

Additionally, this would sometimes swallow `KeyboardInterrupt`, and would sometimes not clean up `TEXINPUTS` properly.
The cleanup is now handled with `contextlib.ExitStack`, which simplifies the return paths and ensures that the cleanup is run even if the code is interrupted with KeyboardInterrupt.